### PR TITLE
Feat/dvb subtitles (CC)

### DIFF
--- a/Emby.Xtream.Plugin/Api/XtreamTunerApi.cs
+++ b/Emby.Xtream.Plugin/Api/XtreamTunerApi.cs
@@ -153,6 +153,11 @@ namespace Emby.Xtream.Plugin.Api
     {
     }
 
+    [Route("/XtreamTuner/StreamStats", "GET", Summary = "Returns cached stream stats received from Dispatcharr for all known streams")]
+    public class GetStreamStats : IReturn<object>
+    {
+    }
+
     public class SyncGuideMappingsResult
     {
         public bool Success { get; set; }
@@ -1058,6 +1063,36 @@ namespace Emby.Xtream.Plugin.Api
                 Logger.Warn("Failed to fetch Dispatcharr profiles: {0}", ex.Message);
                 return new List<Client.Models.DispatcharrProfile>();
             }
+        }
+
+        public object Get(GetStreamStats request)
+        {
+            var stats = XtreamTunerHost.Instance?.StreamStats;
+            if (stats == null || stats.Count == 0)
+                return new { count = 0, message = "No stream stats loaded. Stats are populated when Dispatcharr is enabled and channels have been refreshed.", streams = new object[0] };
+
+            var entries = stats
+                .OrderBy(kv => kv.Key)
+                .Select(kv => new
+                {
+                    stream_id       = kv.Key,
+                    video_codec     = kv.Value.VideoCodec,
+                    resolution      = kv.Value.Resolution,
+                    source_fps      = kv.Value.SourceFps,
+                    bitrate         = kv.Value.Bitrate,
+                    video_profile   = kv.Value.VideoProfile,
+                    video_level     = kv.Value.VideoLevel,
+                    video_bit_depth = kv.Value.VideoBitDepth,
+                    video_ref_frames = kv.Value.VideoRefFrames,
+                    audio_codec     = kv.Value.AudioCodec,
+                    audio_channels  = kv.Value.AudioChannels,
+                    audio_bitrate   = kv.Value.AudioBitrate,
+                    sample_rate     = kv.Value.SampleRate,
+                    audio_language  = kv.Value.AudioLanguage,
+                })
+                .ToList();
+
+            return new { count = entries.Count, streams = entries };
         }
 
         public async Task<object> Get(CheckForUpdate request)

--- a/Emby.Xtream.Plugin/Configuration/Web/config.html
+++ b/Emby.Xtream.Plugin/Configuration/Web/config.html
@@ -974,12 +974,10 @@
                     <div class="checkboxContainer checkboxContainer-withDescription" style="margin-top:0.5em;">
                         <label>
                             <input class="chkDeclareDvbSubtitles" type="checkbox" is="emby-checkbox" />
-                            <span>Declare DVB subtitles</span>
+                            <span>Enable DVB subtitles</span>
                         </label>
                         <div class="fieldDescription checkboxFieldDescription">
-                            Declares DVB subtitle tracks (regular + hearing impaired) so they appear
-                            in Emby without stream probing. Language is detected automatically from
-                            the audio track. Enable if your streams carry DVB subtitles.
+                            Enables DVB subtitles so they appear in Emby without stream probing.
                         </div>
                     </div>
                     <button class="btnRefreshCache raised button-secondary" is="emby-button" type="button" style="margin-top:0.5em;">

--- a/Emby.Xtream.Plugin/Configuration/Web/config.html
+++ b/Emby.Xtream.Plugin/Configuration/Web/config.html
@@ -971,6 +971,17 @@
                             Stream container format. MPEG-TS is recommended for lower latency.
                         </div>
                     </div>
+                    <div class="checkboxContainer checkboxContainer-withDescription" style="margin-top:0.5em;">
+                        <label>
+                            <input class="chkDeclareDvbSubtitles" type="checkbox" is="emby-checkbox" />
+                            <span>Declare DVB subtitles</span>
+                        </label>
+                        <div class="fieldDescription checkboxFieldDescription">
+                            Declares DVB subtitle tracks (regular + hearing impaired) so they appear
+                            in Emby without stream probing. Language is detected automatically from
+                            the audio track. Enable if your streams carry DVB subtitles.
+                        </div>
+                    </div>
                     <button class="btnRefreshCache raised button-secondary" is="emby-button" type="button" style="margin-top:0.5em;">
                         <span>Refresh Channel &amp; EPG Cache</span>
                     </button>

--- a/Emby.Xtream.Plugin/Configuration/Web/config.js
+++ b/Emby.Xtream.Plugin/Configuration/Web/config.js
@@ -46,6 +46,7 @@ function (BaseView, loading) {
             updateDispatcharrVisibility(view);
         });
 
+
         view.querySelector('.selectEpgSource').addEventListener('change', function () {
             updateEpgVisibility(view);
         });
@@ -367,6 +368,7 @@ function (BaseView, loading) {
             view.querySelector('.txtDispatcharrPass').value = config.DispatcharrPass || '';
             view.querySelector('.chkDispatcharrFallback').checked = config.DispatcharrFallbackToXtream !== false;
             view.querySelector('.chkForceAudioTranscode').checked = !!config.ForceAudioTranscode;
+            view.querySelector('.chkDeclareDvbSubtitles').checked = !!config.DeclareDvbSubtitles;
 
             instance.selectedDispatcharrProfileIds = config.SelectedDispatcharrProfileIds || [];
             loadCachedDispatcharrProfiles(instance, config);
@@ -489,6 +491,7 @@ function (BaseView, loading) {
             config.DispatcharrPass = view.querySelector('.txtDispatcharrPass').value;
             config.DispatcharrFallbackToXtream = view.querySelector('.chkDispatcharrFallback').checked;
             config.ForceAudioTranscode = view.querySelector('.chkForceAudioTranscode').checked;
+            config.DeclareDvbSubtitles = view.querySelector('.chkDeclareDvbSubtitles').checked;
             config.SelectedDispatcharrProfileIds = getSelectedDispatcharrProfileIds(instance);
 
             // VOD Movies
@@ -579,7 +582,7 @@ function (BaseView, loading) {
         view.querySelector('.dispatcharrSettings').style.display = enabled ? '' : 'none';
     }
 
-    function updateEpgVisibility(view) {
+function updateEpgVisibility(view) {
         var source = parseInt(view.querySelector('.selectEpgSource').value, 10);
         view.querySelector('.epgSettings').style.display = source !== 2 ? '' : 'none';
         view.querySelector('.epgCustomUrlSettings').style.display = source === 1 ? '' : 'none';

--- a/Emby.Xtream.Plugin/PluginConfiguration.cs
+++ b/Emby.Xtream.Plugin/PluginConfiguration.cs
@@ -41,6 +41,7 @@ namespace Emby.Xtream.Plugin
         public string DispatcharrPass { get; set; } = string.Empty;
         public bool DispatcharrFallbackToXtream { get; set; } = true;
         public bool ForceAudioTranscode { get; set; }
+        public bool DeclareDvbSubtitles { get; set; }
         public int[] SelectedDispatcharrProfileIds { get; set; } = new int[0];
         public string CachedDispatcharrProfiles { get; set; } = string.Empty;
 

--- a/Emby.Xtream.Plugin/Service/XtreamTunerHost.cs
+++ b/Emby.Xtream.Plugin/Service/XtreamTunerHost.cs
@@ -66,6 +66,8 @@ namespace Emby.Xtream.Plugin.Service
 
         public IServerApplicationHost ApplicationHost => _applicationHost;
 
+        public Dictionary<int, StreamStatsInfo> StreamStats => _streamStats;
+
         public override string Name => "Xtream Tuner";
         public override string Type => TunerType;
         public override bool IsSupported => true;
@@ -566,7 +568,7 @@ namespace Emby.Xtream.Plugin.Service
 
             _streamStats.TryGetValue(streamId, out var stats);
 
-            var mediaSource = CreateMediaSourceInfo(streamId, streamUrl, stats, isDispatcharr, config.ForceAudioTranscode, config.HttpUserAgent);
+            var mediaSource = CreateMediaSourceInfo(streamId, streamUrl, stats, isDispatcharr, config.ForceAudioTranscode, config.HttpUserAgent, config.DeclareDvbSubtitles);
             Logger.Info("[stream-timing] ch={0} CreateMediaSource={1}ms hasStats={2}", tunerChannel?.Name, sw.ElapsedMilliseconds, stats != null);
 
             return new List<MediaSourceInfo> { mediaSource };
@@ -600,7 +602,7 @@ namespace Emby.Xtream.Plugin.Service
             Logger.Info("[stream-timing] ch={0} BuildUrl={1}ms isDispatcharr={2}", tunerChannel?.Name, sw.ElapsedMilliseconds, isDispatcharr);
             sw.Restart();
 
-            var mediaSource = CreateMediaSourceInfo(streamId, streamUrl, stats, isDispatcharr, config.ForceAudioTranscode, config.HttpUserAgent);
+            var mediaSource = CreateMediaSourceInfo(streamId, streamUrl, stats, isDispatcharr, config.ForceAudioTranscode, config.HttpUserAgent, config.DeclareDvbSubtitles);
             Logger.Info("[stream-timing] ch={0} CreateMediaSource={1}ms hasStats={2}", tunerChannel?.Name, sw.ElapsedMilliseconds, stats != null);
 
             var httpClient = Plugin.CreateHttpClient();
@@ -1080,7 +1082,7 @@ namespace Emby.Xtream.Plugin.Service
         private MediaSourceInfo CreateMediaSourceInfo(
             int streamId, string streamUrl, StreamStatsInfo stats,
             bool disableProbing = false, bool forceAudioTranscode = false,
-            string userAgent = null)
+            string userAgent = null, bool declareDvbSubtitles = false)
         {
             var sourceId = "xtream_live_" + streamId.ToString(CultureInfo.InvariantCulture);
 
@@ -1247,6 +1249,38 @@ namespace Emby.Xtream.Plugin.Service
                     : (audioCodecLower ?? "aac").ToUpperInvariant();
 
                 mediaStreams.Add(audioStream);
+
+                if (declareDvbSubtitles)
+                {
+                    // Infer language from the audio track — subtitle language matches audio on DVB
+                    var subLang = !string.IsNullOrEmpty(stats?.AudioLanguage) ? stats.AudioLanguage : null;
+                    var langLabel = subLang?.ToUpperInvariant();
+
+                    mediaStreams.Add(new MediaStream
+                    {
+                        Type = MediaStreamType.Subtitle,
+                        Index = mediaStreams.Count,
+                        Codec = "dvb_subtitle",
+                        Language = subLang,
+                        IsExternal = false,
+                        IsForced = false,
+                        IsDefault = false,
+                        DisplayTitle = langLabel != null ? langLabel + " DVBSUB" : "DVB Subtitles",
+                    });
+
+                    mediaStreams.Add(new MediaStream
+                    {
+                        Type = MediaStreamType.Subtitle,
+                        Index = mediaStreams.Count,
+                        Codec = "dvb_subtitle",
+                        Language = subLang,
+                        IsExternal = false,
+                        IsForced = false,
+                        IsDefault = false,
+                        IsHearingImpaired = true,
+                        DisplayTitle = langLabel != null ? langLabel + " SDH DVBSUB" : "DVB Subtitles SDH",
+                    });
+                }
 
                 mediaSource.MediaStreams = mediaStreams;
                 mediaSource.DefaultAudioStreamIndex = isAudioOnly ? 0 : 1;

--- a/docs/decisions/007-dvb-subtitle-static-declaration.md
+++ b/docs/decisions/007-dvb-subtitle-static-declaration.md
@@ -1,0 +1,81 @@
+# ADR-007: DVB Subtitle Support via Static Stream Declaration
+
+**Date**: 2026-04-03
+**Status**: Accepted
+**Affects**: `XtreamTunerHost.CreateMediaSourceInfo()`, `PluginConfiguration`, Live TV config UI
+
+---
+
+## Context
+
+Users watching DVB broadcasts (e.g. Norwegian NRK channels) expect subtitle tracks to be
+selectable in Emby. The plugin disables stream probing by design to enable fast channel
+switching — `AnalyzeDurationMs = 0` and `SupportsProbing = false` are set for Dispatcharr
+proxy URLs. Without probing, Emby never discovers subtitle tracks embedded in the MPEG-TS
+stream, so no subtitle options appear in the player UI.
+
+## Problem
+
+How do we surface DVB subtitle tracks in Emby without re-enabling stream probing?
+
+## Alternatives Considered
+
+### 1. Re-enable probing when subtitles are requested
+
+Set `AnalyzeDurationMs > 0` when a "detect subtitles" option is on.
+
+**Rejected.** For Dispatcharr proxy URLs this is destructive: the probe opens a short-lived
+connection, Dispatcharr interprets the close as the last client leaving and tears down the
+channel, and the real playback connection triggers a retry storm. See CONTRIBUTING.md and
+ADR-001 for the full explanation.
+
+### 2. Fetch subtitle track info from Dispatcharr stream stats
+
+Dispatcharr's `/api/channels/channels/?include_streams=true` already provides per-stream
+codec metadata via Streamflow. The plan was to add subtitle fields to `StreamStatsInfo` and
+use them to declare tracks with correct language tags.
+
+**Rejected.** Querying `GET /XtreamTuner/StreamStats` confirmed that Dispatcharr does not
+expose subtitle track metadata — `audio_language` and any subtitle fields are absent from
+all 150 streams in the test environment. Streamflow only captures video/audio codec info.
+
+### 3. Manual language configuration per channel
+
+Let users map stream IDs to language codes in the plugin config.
+
+**Rejected.** Too complex to maintain and requires users to know the language of every
+channel in advance.
+
+### 4. Global fallback language field
+
+A single text field (e.g. `nor`) used as the language tag on all declared subtitle tracks.
+
+**Partially implemented, then removed.** Added and removed during development because
+`audio_language` is absent from Dispatcharr stats, making even the auto-inference approach
+fail. A manual global field adds UI complexity for marginal benefit — the tracks work
+regardless of whether a language tag is present, they just show as "DVB Subtitles" instead
+of e.g. "Norwegian (DVBSUB)".
+
+## Decision
+
+Declare subtitle `MediaStream` entries statically in `CreateMediaSourceInfo()` when the
+`DeclareDvbSubtitles` config flag is set. Two tracks are always declared: one regular
+(`dvb_subtitle`) and one hearing impaired (`dvb_subtitle` + `IsHearingImpaired = true`).
+No language tag is set since the source does not provide this information.
+
+A single toggle — **"Enable DVB subtitles"** — is added to the Live TV settings tab,
+outside the Dispatcharr section so it works for both direct Xtream and Dispatcharr users.
+
+A diagnostic endpoint `GET /XtreamTuner/StreamStats` is also added so users can inspect
+the raw stats received from Dispatcharr, useful for future debugging.
+
+## Consequences
+
+- Subtitle tracks appear in Emby without any probing overhead.
+- Fast channel switching is preserved.
+- Tracks show as "DVB Subtitles" and "DVB Subtitles SDH" — no language name, because
+  Dispatcharr does not provide it.
+- Channels that carry no subtitles will show the two tracks anyway; ffmpeg will find
+  nothing to map and the options will silently produce no output. This is acceptable.
+- If Dispatcharr adds subtitle/language metadata in a future release, `StreamStatsInfo`
+  can be extended and the language inference re-introduced.


### PR DESCRIPTION
Added the ability to enable CC/DVB subtitles from the xstream. The config was put under the LiveTV tab. 