### PR TITLE
fix: run Xtream connection test server-side (closes #33)

### DIFF
--- a/Emby.Xtream.Plugin/Api/XtreamTunerApi.cs
+++ b/Emby.Xtream.Plugin/Api/XtreamTunerApi.cs
@@ -95,6 +95,9 @@ namespace Emby.Xtream.Plugin.Api
     [Route("/XtreamTuner/TestConnection", "POST", Summary = "Tests connection to Xtream server")]
     public class TestXtreamConnection : IReturn<TestConnectionResult>
     {
+        public string BaseUrl { get; set; }
+        public string Username { get; set; }
+        public string Password { get; set; }
     }
 
     [Route("/XtreamTuner/TestDispatcharr", "POST", Summary = "Tests connection to Dispatcharr")]
@@ -938,12 +941,18 @@ namespace Emby.Xtream.Plugin.Api
             var config = Plugin.Instance.Configuration;
             var result = new TestConnectionResult();
 
-            if (string.IsNullOrEmpty(config.BaseUrl) ||
-                string.IsNullOrEmpty(config.Username) ||
-                string.IsNullOrEmpty(config.Password))
+            // Prefer the values supplied in the request (the unsaved form values) so the
+            // connection can be tested before saving; fall back to the persisted config.
+            var baseUrl = !string.IsNullOrEmpty(request.BaseUrl) ? request.BaseUrl.TrimEnd('/') : config.BaseUrl;
+            var username = !string.IsNullOrEmpty(request.Username) ? request.Username : config.Username;
+            var password = !string.IsNullOrEmpty(request.Password) ? request.Password : config.Password;
+
+            if (string.IsNullOrEmpty(baseUrl) ||
+                string.IsNullOrEmpty(username) ||
+                string.IsNullOrEmpty(password))
             {
                 result.Success = false;
-                result.Message = "Please configure server URL, username, and password first.";
+                result.Message = "Please enter server URL, username, and password.";
                 return result;
             }
 
@@ -952,7 +961,7 @@ namespace Emby.Xtream.Plugin.Api
                 var url = string.Format(
                     System.Globalization.CultureInfo.InvariantCulture,
                     "{0}/player_api.php?username={1}&password={2}",
-                    config.BaseUrl, Uri.EscapeDataString(config.Username), Uri.EscapeDataString(config.Password));
+                    baseUrl, Uri.EscapeDataString(username), Uri.EscapeDataString(password));
 
                 using (var httpClient = Plugin.CreateHttpClient())
                 {
@@ -981,7 +990,20 @@ namespace Emby.Xtream.Plugin.Api
                                 if (auth == 1)
                                 {
                                     result.Success = true;
-                                    result.Message = "Connection successful!";
+                                    var msg = string.Format(
+                                        System.Globalization.CultureInfo.InvariantCulture,
+                                        "Connected as {0} — status: {1}",
+                                        username, status ?? "unknown");
+
+                                    if (userInfo.TryGetProperty("active_cons", out var activeEl))
+                                    {
+                                        msg += ", " + activeEl.ToString();
+                                        if (userInfo.TryGetProperty("max_connections", out var maxEl))
+                                            msg += "/" + maxEl.ToString();
+                                        msg += " active streams";
+                                    }
+
+                                    result.Message = msg;
                                 }
                                 else
                                 {

--- a/Emby.Xtream.Plugin/Configuration/Web/config.js
+++ b/Emby.Xtream.Plugin/Configuration/Web/config.js
@@ -851,47 +851,22 @@ function updateEpgVisibility(view) {
             return;
         }
 
-        var testUrl = url + '/player_api.php?username=' + encodeURIComponent(user) + '&password=' + encodeURIComponent(pass);
-        var xhr = new XMLHttpRequest();
-        xhr.open('GET', testUrl, true);
-        xhr.timeout = 10000;
-
-        xhr.onload = function () {
-            if (xhr.status >= 200 && xhr.status < 300) {
-                try {
-                    var resp = JSON.parse(xhr.responseText);
-                    if (resp.user_info) {
-                        var status = resp.user_info.status || 'unknown';
-                        var msg = 'Connected as ' + user + ' — status: ' + status;
-                        if (resp.user_info.active_cons !== undefined) {
-                            msg += ', ' + resp.user_info.active_cons;
-                            if (resp.user_info.max_connections !== undefined) {
-                                msg += '/' + resp.user_info.max_connections;
-                            }
-                            msg += ' active streams';
-                        }
-                        setPillResult(resultEl, true, msg);
-                    } else {
-                        setPillResult(resultEl, true, 'Connection successful!');
-                    }
-                } catch (e) {
-                    setPillResult(resultEl, true, 'Connection successful (non-JSON response).');
-                }
+        // Run the test server-side so it can reach hosts that the browser cannot
+        // resolve (e.g. Docker container names on the Emby server's network).
+        ApiClient.ajax({
+            type: 'POST',
+            url: ApiClient.getUrl('XtreamTuner/TestConnection'),
+            contentType: 'application/json',
+            data: JSON.stringify({ BaseUrl: url, Username: user, Password: pass }),
+            dataType: 'json'
+        }).then(function (result) {
+            setPillResult(resultEl, result.Success, result.Message);
+            if (result.Success) {
                 saveConfig(instance);
-            } else {
-                setPillResult(resultEl, false, 'Connection failed (HTTP ' + xhr.status + ').');
             }
-        };
-
-        xhr.onerror = function () {
-            setPillResult(resultEl, false, 'Connection failed. Check URL and ensure server is reachable.');
-        };
-
-        xhr.ontimeout = function () {
-            setPillResult(resultEl, false, 'Connection timed out.');
-        };
-
-        xhr.send();
+        }).catch(function () {
+            setPillResult(resultEl, false, 'Test request failed. Check server logs.');
+        });
     }
 
     // ---- Folder browser ----


### PR DESCRIPTION
Moves xtream tests into an internal API for Docker container resolution