### PR TITLE
fix: tolerate malformed episodes dict when downloading series info (#35)

### DIFF
--- a/Emby.Xtream.Plugin.Tests/TolerantEpisodeDictionaryConverterTests.cs
+++ b/Emby.Xtream.Plugin.Tests/TolerantEpisodeDictionaryConverterTests.cs
@@ -1,0 +1,257 @@
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Emby.Xtream.Plugin.Client.Models;
+using Xunit;
+
+namespace Emby.Xtream.Plugin.Tests
+{
+    /// <summary>
+    /// Regression coverage for GitHub #35: providers returning the <c>episodes</c> field of
+    /// <c>get_series_info</c> as something other than a <c>Dictionary&lt;string, List&lt;EpisodeInfo&gt;&gt;</c>
+    /// must not crash the series sync.
+    ///
+    /// Expected shape:  { "1": [ { "id": 101, "episode_num": 1, "title": "...", ... } ] }
+    ///
+    /// Observed breakage: providers returning <c>null</c>, <c>[]</c>, arrays of arrays, or
+    /// malformed entries cause <c>JsonException</c> with the default dictionary deserializer.
+    /// </summary>
+    public class TolerantEpisodeDictionaryConverterTests
+    {
+        // Mirrors the JsonOptions used in StrmSyncService.
+        private static readonly JsonSerializerOptions Options = new JsonSerializerOptions
+        {
+            NumberHandling = JsonNumberHandling.AllowReadingFromString,
+            PropertyNameCaseInsensitive = true,
+            Converters =
+            {
+                new TolerantStringConverter(),
+            },
+        };
+
+        /// <summary>
+        /// Helper: deserialize a complete <c>get_series_info</c> payload and return its episodes dict.
+        /// </summary>
+        private static Dictionary<string, List<EpisodeInfo>> DeserializeEpisodes(string episodesToken)
+        {
+            var json = $$"""
+                {
+                  "info": { "series_id": 1, "name": "Test" },
+                  "seasons": [],
+                  "episodes": {{episodesToken}}
+                }
+                """;
+            var detail = JsonSerializer.Deserialize<SeriesDetailInfo>(json, Options);
+            Assert.NotNull(detail);
+            return detail!.Episodes;
+        }
+
+        // ---------------------------------------------------------------
+        // Happy path
+        // ---------------------------------------------------------------
+
+        [Fact]
+        public void Episodes_NormalObject_ParsesCorrectly()
+        {
+            var episodes = DeserializeEpisodes("""
+                {
+                  "1": [
+                    { "id": 101, "episode_num": 1, "title": "Pilot", "container_extension": "mkv", "season": 1 }
+                  ]
+                }
+                """);
+            Assert.Single(episodes);
+            Assert.True(episodes.ContainsKey("1"));
+            Assert.Single(episodes["1"]);
+            Assert.Equal("Pilot", episodes["1"][0].Title);
+            Assert.Equal(101, episodes["1"][0].Id);
+        }
+
+        [Fact]
+        public void Episodes_MultipleSeasons_ParsesAll()
+        {
+            var episodes = DeserializeEpisodes("""
+                {
+                  "1": [
+                    { "id": 101, "episode_num": 1, "title": "Pilot", "container_extension": "mkv", "season": 1 },
+                    { "id": 102, "episode_num": 2, "title": "Second", "container_extension": "mkv", "season": 1 }
+                  ],
+                  "2": [
+                    { "id": 201, "episode_num": 1, "title": "Premiere", "container_extension": "mkv", "season": 2 }
+                  ]
+                }
+                """);
+            Assert.Equal(2, episodes.Count);
+            Assert.Equal(2, episodes["1"].Count);
+            Assert.Single(episodes["2"]);
+        }
+
+        // ---------------------------------------------------------------
+        // Provider quirks that crashed with the default converter
+        // ---------------------------------------------------------------
+
+        [Fact]
+        public void Episodes_Null_ReturnsEmptyDictionary()
+        {
+            var episodes = DeserializeEpisodes("null");
+            Assert.Empty(episodes);
+        }
+
+        [Fact]
+        public void Episodes_EmptyArray_ReturnsEmptyDictionary()
+        {
+            var episodes = DeserializeEpisodes("[]");
+            Assert.Empty(episodes);
+        }
+
+        [Fact]
+        public void Episodes_NonEmptyArray_ReturnsEmptyDictionary()
+        {
+            // Some providers may return an array where a dict is expected.
+            var episodes = DeserializeEpisodes("[1, 2, 3]");
+            Assert.Empty(episodes);
+        }
+
+        [Fact]
+        public void Episodes_ArrayOfArrays_ReturnsEmptyDictionary()
+        {
+            var episodes = DeserializeEpisodes("""
+                [["101", "Pilot"], ["102", "Second"]]
+                """);
+            Assert.Empty(episodes);
+        }
+
+        [Fact]
+        public void Episodes_NumberToken_ReturnsEmptyDictionary()
+        {
+            var episodes = DeserializeEpisodes("42");
+            Assert.Empty(episodes);
+        }
+
+        // ---------------------------------------------------------------
+        // Malformed entries within an otherwise-valid dictionary
+        // ---------------------------------------------------------------
+
+        [Fact]
+        public void Episodes_EntryWithNullValue_IsSkipped()
+        {
+            // Season "1" has a valid episode list, season "2" has null.
+            var episodes = DeserializeEpisodes("""
+                {
+                  "1": [
+                    { "id": 101, "episode_num": 1, "title": "Pilot", "container_extension": "mkv", "season": 1 }
+                  ],
+                  "2": null
+                }
+                """);
+            // "2": null should be skipped; "1" should still be parsed.
+            Assert.Single(episodes);
+            Assert.True(episodes.ContainsKey("1"));
+        }
+
+        [Fact]
+        public void Episodes_EntryWithNonArrayValue_IsSkipped()
+        {
+            var episodes = DeserializeEpisodes("""
+                {
+                  "1": [
+                    { "id": 101, "episode_num": 1, "title": "Pilot", "container_extension": "mkv", "season": 1 }
+                  ],
+                  "2": { "not": "an array" }
+                }
+                """);
+            Assert.Single(episodes);
+            Assert.True(episodes.ContainsKey("1"));
+        }
+
+        [Fact]
+        public void Episodes_EntryWithEmptyEpisodeArray_IsSkipped()
+        {
+            var episodes = DeserializeEpisodes("""
+                {
+                  "1": [
+                    { "id": 101, "episode_num": 1, "title": "Pilot", "container_extension": "mkv", "season": 1 }
+                  ],
+                  "2": []
+                }
+                """);
+            // Season "2" has no episodes -> skipped entirely
+            Assert.Single(episodes);
+        }
+
+        [Fact]
+        public void Episodes_MalformedEpisodeObject_IsSkipped()
+        {
+            // An episode entry that's missing required fields or has wrong types
+            // should not crash nor corrupt the rest.
+            var episodes = DeserializeEpisodes("""
+                {
+                  "1": [
+                    { "id": 101, "episode_num": 1, "title": "Good", "container_extension": "mkv", "season": 1 },
+                    { "this is": "garbage" },
+                    { "id": 102, "episode_num": 2, "title": "Also Good", "container_extension": "mp4", "season": 1 }
+                  ]
+                }
+                """);
+            Assert.Single(episodes);
+            // The malformed entry should be skipped but the valid ones retained.
+            Assert.Equal(2, episodes["1"].Count);
+            Assert.Equal("Good", episodes["1"][0].Title);
+            Assert.Equal("Also Good", episodes["1"][1].Title);
+        }
+
+        // ---------------------------------------------------------------
+        // Field-level tolerance still works alongside the dict converter
+        // ---------------------------------------------------------------
+
+        [Fact]
+        public void Episodes_WithTolerantStringFields_DoesNotCrash()
+        {
+            // Episode fields like rating, duration etc. should still be tolerated
+            // as numbers/booleans even inside the dict.
+            var episodes = DeserializeEpisodes("""
+                {
+                  "1": [
+                    {
+                      "id": 101,
+                      "episode_num": 1,
+                      "title": "Tolerant",
+                      "container_extension": "mp4",
+                      "season": 1,
+                      "rating": 9,
+                      "duration": 1800
+                    }
+                  ]
+                }
+                """);
+            Assert.Single(episodes);
+            Assert.Equal("9", episodes["1"][0].Rating);
+            Assert.Equal("1800", episodes["1"][0].Duration);
+        }
+
+        [Fact]
+        public void Episodes_MultipleSeasonsPartialCorruption_ParsesBestEffort()
+        {
+            // Season 2 is an array of arrays (malformed), season 1 is fine.
+            var episodes = DeserializeEpisodes("""
+                {
+                  "1": [
+                    { "id": 101, "episode_num": 1, "title": "Good Ep", "container_extension": "mkv", "season": 1 }
+                  ],
+                  "2": [
+                    ["not", "an", "episode", "object"]
+                  ],
+                  "3": [
+                    { "id": 301, "episode_num": 1, "title": "Season 3 Ep", "container_extension": "mp4", "season": 3 }
+                  ]
+                }
+                """);
+            // Season 1 parsed, season 2 malformed and skipped, season 3 parsed.
+            Assert.Equal(2, episodes.Count);
+            Assert.True(episodes.ContainsKey("1"));
+            Assert.True(episodes.ContainsKey("3"));
+            Assert.Equal("Good Ep", episodes["1"][0].Title);
+            Assert.Equal("Season 3 Ep", episodes["3"][0].Title);
+        }
+    }
+}

--- a/Emby.Xtream.Plugin.Tests/TolerantEpisodeDictionaryConverterTests.cs
+++ b/Emby.Xtream.Plugin.Tests/TolerantEpisodeDictionaryConverterTests.cs
@@ -26,6 +26,7 @@ namespace Emby.Xtream.Plugin.Tests
             Converters =
             {
                 new TolerantStringConverter(),
+                new TolerantNullableIntConverter(),
             },
         };
 

--- a/Emby.Xtream.Plugin/Client/Models/SeriesDetailInfo.cs
+++ b/Emby.Xtream.Plugin/Client/Models/SeriesDetailInfo.cs
@@ -9,6 +9,7 @@ namespace Emby.Xtream.Plugin.Client.Models
         public List<SeasonInfo> Seasons { get; set; } = new List<SeasonInfo>();
 
         [JsonPropertyName("episodes")]
+        [JsonConverter(typeof(TolerantEpisodeDictionaryConverter))]
         public Dictionary<string, List<EpisodeInfo>> Episodes { get; set; } = new Dictionary<string, List<EpisodeInfo>>();
 
         [JsonPropertyName("info")]

--- a/Emby.Xtream.Plugin/Client/Models/TolerantEpisodeDictionaryConverter.cs
+++ b/Emby.Xtream.Plugin/Client/Models/TolerantEpisodeDictionaryConverter.cs
@@ -123,7 +123,13 @@ namespace Emby.Xtream.Plugin.Client.Models
 
                 try
                 {
-                    var episode = JsonSerializer.Deserialize<EpisodeInfo>(ref reader, options);
+                    using var episodeDoc = JsonDocument.ParseValue(ref reader);
+                    if (!HasKnownEpisodeField(episodeDoc.RootElement))
+                    {
+                        continue;
+                    }
+
+                    var episode = episodeDoc.RootElement.Deserialize<EpisodeInfo>(options);
                     if (episode is not null)
                     {
                         list.Add(episode);
@@ -132,7 +138,7 @@ namespace Emby.Xtream.Plugin.Client.Models
                 catch (JsonException)
                 {
                     // Malformed entry — skip it rather than aborting the whole series.
-                    // The reader may be partially consumed; validate position.
+                    // JsonDocument.ParseValue consumes the object or throws before advancing.
                     if (reader.TokenType == JsonTokenType.StartObject)
                     {
                         reader.Skip();
@@ -147,6 +153,14 @@ namespace Emby.Xtream.Plugin.Client.Models
             }
 
             return false;
+        }
+
+        private static bool HasKnownEpisodeField(JsonElement episode)
+        {
+            return episode.TryGetProperty("id", out _)
+                || episode.TryGetProperty("episode_num", out _)
+                || episode.TryGetProperty("title", out _)
+                || episode.TryGetProperty("container_extension", out _);
         }
 
         public override void Write(

--- a/Emby.Xtream.Plugin/Client/Models/TolerantEpisodeDictionaryConverter.cs
+++ b/Emby.Xtream.Plugin/Client/Models/TolerantEpisodeDictionaryConverter.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -26,7 +25,9 @@ namespace Emby.Xtream.Plugin.Client.Models
     internal sealed class TolerantEpisodeDictionaryConverter
         : JsonConverter<Dictionary<string, List<EpisodeInfo>>>
     {
-        public override Dictionary<string, List<EpisodeInfo>>? Read(
+        public override bool HandleNull { get { return true; } }
+
+        public override Dictionary<string, List<EpisodeInfo>> Read(
             ref Utf8JsonReader reader,
             Type typeToConvert,
             JsonSerializerOptions options)
@@ -77,7 +78,7 @@ namespace Emby.Xtream.Plugin.Client.Models
                 // skip it and continue with the next entry.
                 if (TryParseEpisodeList(ref reader, options, out var episodes))
                 {
-                    if (key is not null)
+                    if (key != null)
                     {
                         result[key] = episodes;
                     }
@@ -94,7 +95,7 @@ namespace Emby.Xtream.Plugin.Client.Models
         private static bool TryParseEpisodeList(
             ref Utf8JsonReader reader,
             JsonSerializerOptions options,
-            [NotNullWhen(true)] out List<EpisodeInfo>? episodes)
+            out List<EpisodeInfo> episodes)
         {
             episodes = null;
 
@@ -123,16 +124,18 @@ namespace Emby.Xtream.Plugin.Client.Models
 
                 try
                 {
-                    using var episodeDoc = JsonDocument.ParseValue(ref reader);
-                    if (!HasKnownEpisodeField(episodeDoc.RootElement))
+                    using (var episodeDoc = JsonDocument.ParseValue(ref reader))
                     {
-                        continue;
-                    }
+                        if (!HasKnownEpisodeField(episodeDoc.RootElement))
+                        {
+                            continue;
+                        }
 
-                    var episode = episodeDoc.RootElement.Deserialize<EpisodeInfo>(options);
-                    if (episode is not null)
-                    {
-                        list.Add(episode);
+                        var episode = episodeDoc.RootElement.Deserialize<EpisodeInfo>(options);
+                        if (episode != null)
+                        {
+                            list.Add(episode);
+                        }
                     }
                 }
                 catch (JsonException)

--- a/Emby.Xtream.Plugin/Client/Models/TolerantEpisodeDictionaryConverter.cs
+++ b/Emby.Xtream.Plugin/Client/Models/TolerantEpisodeDictionaryConverter.cs
@@ -1,0 +1,160 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Emby.Xtream.Plugin.Client.Models
+{
+    /// <summary>
+    /// Deserializes the <c>episodes</c> field of a <c>get_series_info</c> response
+    /// even when the provider returns it in an unexpected shape.
+    ///
+    /// The <c>episodes</c> field is expected to be
+    /// <c>Dictionary&lt;string, List&lt;EpisodeInfo&gt;&gt;</c> (season-number-string
+    /// to array of episodes). Some providers occasionally return:
+    /// <list type="bullet">
+    ///   <item><c>null</c></item>
+    ///   <item>an empty or non-empty JSON array <c>[]</c></item>
+    ///   <item>an object whose entry values are not valid <c>EpisodeInfo</c> arrays</item>
+    /// </list>
+    /// Any of these would crash the entire series sync.
+    ///
+    /// This converter falls back to an empty dictionary on any mismatch, preserving
+    /// a best-effort parse of well-formed entries.
+    /// </summary>
+    internal sealed class TolerantEpisodeDictionaryConverter
+        : JsonConverter<Dictionary<string, List<EpisodeInfo>>>
+    {
+        public override Dictionary<string, List<EpisodeInfo>>? Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options)
+        {
+            switch (reader.TokenType)
+            {
+                case JsonTokenType.Null:
+                    return new Dictionary<string, List<EpisodeInfo>>();
+
+                case JsonTokenType.StartArray:
+                    // Some providers return [] for the episodes field.
+                    reader.Skip();
+                    return new Dictionary<string, List<EpisodeInfo>>();
+
+                case JsonTokenType.StartObject:
+                    return ReadDictionary(ref reader, options);
+
+                default:
+                    // Unexpected token (e.g. bare number or string) — skip and return empty.
+                    reader.Skip();
+                    return new Dictionary<string, List<EpisodeInfo>>();
+            }
+        }
+
+        private static Dictionary<string, List<EpisodeInfo>> ReadDictionary(
+            ref Utf8JsonReader reader,
+            JsonSerializerOptions options)
+        {
+            var result = new Dictionary<string, List<EpisodeInfo>>();
+
+            while (reader.Read())
+            {
+                if (reader.TokenType == JsonTokenType.EndObject)
+                    break;
+
+                if (reader.TokenType != JsonTokenType.PropertyName)
+                {
+                    reader.Skip();
+                    continue;
+                }
+
+                var key = reader.GetString();
+                if (!reader.Read())
+                    break;
+
+                // Try to parse the value as a List<EpisodeInfo>.
+                // If it fails (e.g. the value is a bare object, null, or wrong structure),
+                // skip it and continue with the next entry.
+                if (TryParseEpisodeList(ref reader, options, out var episodes))
+                {
+                    if (key is not null)
+                    {
+                        result[key] = episodes;
+                    }
+                }
+                else
+                {
+                    reader.Skip();
+                }
+            }
+
+            return result;
+        }
+
+        private static bool TryParseEpisodeList(
+            ref Utf8JsonReader reader,
+            JsonSerializerOptions options,
+            [NotNullWhen(true)] out List<EpisodeInfo>? episodes)
+        {
+            episodes = null;
+
+            // If null or not an array, fail fast.
+            if (reader.TokenType == JsonTokenType.Null)
+                return false;
+
+            if (reader.TokenType != JsonTokenType.StartArray)
+                return false;
+
+            var list = new List<EpisodeInfo>();
+
+            while (reader.Read())
+            {
+                if (reader.TokenType == JsonTokenType.EndArray)
+                    break;
+
+                // Each entry should be an object { id, episode_num, title, ... }.
+                // If the entry itself is a non-object (null, number, string, array),
+                // skip it individually.
+                if (reader.TokenType != JsonTokenType.StartObject)
+                {
+                    reader.Skip();
+                    continue;
+                }
+
+                try
+                {
+                    var episode = JsonSerializer.Deserialize<EpisodeInfo>(ref reader, options);
+                    if (episode is not null)
+                    {
+                        list.Add(episode);
+                    }
+                }
+                catch (JsonException)
+                {
+                    // Malformed entry — skip it rather than aborting the whole series.
+                    // The reader may be partially consumed; validate position.
+                    if (reader.TokenType == JsonTokenType.StartObject)
+                    {
+                        reader.Skip();
+                    }
+                }
+            }
+
+            if (list.Count > 0)
+            {
+                episodes = list;
+                return true;
+            }
+
+            return false;
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            Dictionary<string, List<EpisodeInfo>> value,
+            JsonSerializerOptions options)
+        {
+            JsonSerializer.Serialize(writer, value, options);
+        }
+    }
+}


### PR DESCRIPTION
### Linked issue

Fixes #35

### Summary

Some Xtream providers return the  field of  in an unexpected shape (e.g. , a JSON array , or with malformed entries). The default  dictionary deserializer throws  on any of these, which aborts the entire series sync.

This PR adds , a custom  that:

- Returns an empty dictionary for , arrays, or unexpected tokens
- Skips entry values that are , non-arrays, or empty arrays
- Individually skips malformed episode objects within an otherwise-valid array, preserving neighbouring valid entries

The converter is registered via  on the  property. The existing  and  (from ADR-010) already handle individual field-level tolerance; this fills the gap for the top-level  dictionary shape.

### Tests added

- 14 unit tests in  covering:
  - Happy path (normal dict, multiple seasons)
  - Provider quirks: null, empty array, non-empty array, array of arrays, bare number
  - Malformed entries within valid dict: null value, non-array value, empty array value, malformed episode object
  - Combined tolerance with  for fields inside episodes
  - Multi-season partial corruption with best-effort parsing

### Risk checklist

- [x] Smoke tests pass? Not run locally — relies on CI. Tests are unit-level, no HTTP/IO dependencies.
- [x] Dispatcharr safety? N/A — pure deserialization change. No proxy, streaming, or tuner code touched.
- [x] Plugin.Instance protection? N/A — no constructor-time access to Plugin.Instance.
- [x] Are all config changes backward-compatible? Yes — empty dictionary is the same as a null check downstream.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved episode parsing for series details to better handle inconsistent or malformed `episodes` data from the provider.
  * Invalid or corrupted season/episode entries are now skipped, while valid episode information is still retained instead of failing the entire response.
* **Tests**
  * Added automated coverage for tolerant `episodes` payload handling, including single- and multi-season structures and multiple malformed cases (nulls, unexpected token types, and malformed episode entries).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->