### PR TITLE
ci: make PR notify webhook non-blocking

### DIFF
--- a/.github/workflows/pr-ready-notify.yml
+++ b/.github/workflows/pr-ready-notify.yml
@@ -68,6 +68,7 @@ jobs:
 
       - name: Send notification webhook
         if: env.PR_NOTIFY_WEBHOOK_URL != ''
+        continue-on-error: true
         env:
           PAYLOAD: ${{ steps.payload.outputs.payload }}
         run: |


### PR DESCRIPTION
## Summary
- Make the PR notification webhook step non-blocking with `continue-on-error: true`.
- Keeps PR/update notifications best-effort while Hermes cron polling is the reliable fallback.
- Prevents a stale or invalid `PR_NOTIFY_WEBHOOK_URL` secret from marking otherwise valid PRs red.

## Verification
- Validated the workflow contains exactly one `continue-on-error: true` on the webhook delivery step.
- No code/runtime changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved workflow resilience to better handle notification delivery scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->