### PR TITLE
fix: restore live stream consumer hooks (#40)

### DIFF
--- a/Emby.Xtream.Plugin.Tests/XtreamLiveStreamTests.cs
+++ b/Emby.Xtream.Plugin.Tests/XtreamLiveStreamTests.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using Emby.Xtream.Plugin.Service;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Model.Dto;
+using Xunit;
+
+namespace Emby.Xtream.Plugin.Tests
+{
+    public class XtreamLiveStreamTests
+    {
+        [Fact]
+        public void ExposesConsumerLifecycleMethodsForEmbyRuntimeCompatibility()
+        {
+            var type = typeof(XtreamLiveStream);
+
+            Assert.NotNull(type.GetMethod("AddConsumer", BindingFlags.Instance | BindingFlags.Public));
+            Assert.NotNull(type.GetMethod("RemoveConsumer", BindingFlags.Instance | BindingFlags.Public));
+        }
+
+        [Fact]
+        public void AddConsumerAndRemoveConsumerMaintainConsumerCount()
+        {
+            using (var stream = CreateStream())
+            {
+                stream.AddConsumer();
+                stream.AddConsumer();
+
+                Assert.Equal(2, stream.ConsumerCount);
+
+                stream.RemoveConsumer();
+                stream.RemoveConsumer();
+                stream.RemoveConsumer();
+
+                Assert.Equal(0, stream.ConsumerCount);
+            }
+        }
+
+        [Fact]
+        public void ConsumerLifecycleMethodsAreThreadSafe()
+        {
+            using (var stream = CreateStream())
+            {
+                const int threadCount = 20;
+                const int operationsPerThread = 1000;
+                using (var startBarrier = new Barrier(threadCount + 1))
+                using (var postAddBarrier = new Barrier(threadCount + 1))
+                using (var removeBarrier = new Barrier(threadCount + 1))
+                {
+                    var threads = Enumerable.Range(0, threadCount)
+                        .Select(_ => new Thread(() =>
+                        {
+                            startBarrier.SignalAndWait();
+                            for (var i = 0; i < operationsPerThread; i++)
+                            {
+                                stream.AddConsumer();
+                            }
+
+                            postAddBarrier.SignalAndWait();
+                            removeBarrier.SignalAndWait();
+                            for (var i = 0; i < operationsPerThread; i++)
+                            {
+                                stream.RemoveConsumer();
+                            }
+                        }))
+                        .ToArray();
+
+                    foreach (var thread in threads) thread.Start();
+                    startBarrier.SignalAndWait();
+                    postAddBarrier.SignalAndWait();
+                    Assert.Equal(threadCount * operationsPerThread, stream.ConsumerCount);
+                    removeBarrier.SignalAndWait();
+                    foreach (var thread in threads) thread.Join();
+                }
+
+                Assert.Equal(0, stream.ConsumerCount);
+            }
+        }
+
+        [Fact]
+        public void AddConsumerAndRemoveConsumerRemainPublicMethodsUntilEmbyReferencesExposeRuntimeSlots()
+        {
+            var interfaceMethodNames = typeof(ILiveStream).GetMethods().Select(method => method.Name).ToArray();
+
+            Assert.DoesNotContain("AddConsumer", interfaceMethodNames);
+            Assert.DoesNotContain("RemoveConsumer", interfaceMethodNames);
+            Assert.NotNull(typeof(XtreamLiveStream).GetMethod("AddConsumer"));
+            Assert.NotNull(typeof(XtreamLiveStream).GetMethod("RemoveConsumer"));
+        }
+
+        private static XtreamLiveStream CreateStream()
+        {
+            return new XtreamLiveStream(
+                new MediaSourceInfo
+                {
+                    Id = "stream-1",
+                    Path = "http://example.invalid/live.ts"
+                },
+                "tuner-1",
+                new System.Net.Http.HttpClient());
+        }
+    }
+}

--- a/Emby.Xtream.Plugin.Tests/XtreamLiveStreamTests.cs
+++ b/Emby.Xtream.Plugin.Tests/XtreamLiveStreamTests.cs
@@ -16,8 +16,13 @@ namespace Emby.Xtream.Plugin.Tests
         {
             var type = typeof(XtreamLiveStream);
 
-            Assert.NotNull(type.GetMethod("AddConsumer", BindingFlags.Instance | BindingFlags.Public));
-            Assert.NotNull(type.GetMethod("RemoveConsumer", BindingFlags.Instance | BindingFlags.Public));
+            var addConsumer = type.GetMethod("AddConsumer", BindingFlags.Instance | BindingFlags.Public);
+            var removeConsumer = type.GetMethod("RemoveConsumer", BindingFlags.Instance | BindingFlags.Public);
+
+            Assert.NotNull(addConsumer);
+            Assert.NotNull(removeConsumer);
+            Assert.True(addConsumer.IsVirtual);
+            Assert.True(removeConsumer.IsVirtual);
         }
 
         [Fact]
@@ -70,9 +75,11 @@ namespace Emby.Xtream.Plugin.Tests
                     foreach (var thread in threads) thread.Start();
                     startBarrier.SignalAndWait();
                     postAddBarrier.SignalAndWait();
-                    Assert.Equal(threadCount * operationsPerThread, stream.ConsumerCount);
+                    var consumerCountAfterAdds = stream.ConsumerCount;
                     removeBarrier.SignalAndWait();
                     foreach (var thread in threads) thread.Join();
+
+                    Assert.Equal(threadCount * operationsPerThread, consumerCountAfterAdds);
                 }
 
                 Assert.Equal(0, stream.ConsumerCount);

--- a/Emby.Xtream.Plugin/Service/XtreamLiveStream.cs
+++ b/Emby.Xtream.Plugin/Service/XtreamLiveStream.cs
@@ -31,7 +31,14 @@ namespace Emby.Xtream.Plugin.Service
             DateOpened = DateTimeOffset.UtcNow;
         }
 
-        public int ConsumerCount { get; set; }
+        private int _consumerCount;
+
+        public int ConsumerCount
+        {
+            get => Volatile.Read(ref _consumerCount);
+            set => Volatile.Write(ref _consumerCount, Math.Max(0, value));
+        }
+
         public string OriginalStreamId { get; set; }
         public string TunerHostId { get; }
         public bool EnableStreamSharing => false;
@@ -70,6 +77,23 @@ namespace Emby.Xtream.Plugin.Service
         {
             Dispose();
             return Task.CompletedTask;
+        }
+
+        public void AddConsumer()
+        {
+            Interlocked.Increment(ref _consumerCount);
+        }
+
+        public void RemoveConsumer()
+        {
+            while (true)
+            {
+                var current = Volatile.Read(ref _consumerCount);
+                if (current <= 0) return;
+
+                if (Interlocked.CompareExchange(ref _consumerCount, current - 1, current) == current)
+                    return;
+            }
         }
 
         // Reopen the HTTP connection to the upstream source. Called when a prior CopyToAsync

--- a/Emby.Xtream.Plugin/Service/XtreamLiveStream.cs
+++ b/Emby.Xtream.Plugin/Service/XtreamLiveStream.cs
@@ -11,7 +11,7 @@ using MediaBrowser.Model.Logging;
 
 namespace Emby.Xtream.Plugin.Service
 {
-    internal sealed class XtreamLiveStream : ILiveStream, IDisposable
+    internal class XtreamLiveStream : ILiveStream, IDisposable
     {
         private readonly HttpClient _httpClient;
         private readonly ILogger _logger;
@@ -79,12 +79,12 @@ namespace Emby.Xtream.Plugin.Service
             return Task.CompletedTask;
         }
 
-        public void AddConsumer()
+        public virtual void AddConsumer()
         {
             Interlocked.Increment(ref _consumerCount);
         }
 
-        public void RemoveConsumer()
+        public virtual void RemoveConsumer()
         {
             while (true)
             {


### PR DESCRIPTION
### Linked issue

Fixes #40

### Summary

Emby 4.10 beta calls `AddConsumer()` / `RemoveConsumer()` on live stream instances during playback. `XtreamLiveStream` did not expose those runtime hooks, so live TV playback failed immediately with:

`Method 'AddConsumer' in type 'Emby.Xtream.Plugin.Service.XtreamLiveStream' ... does not have an implementation.`

This PR adds the consumer lifecycle methods and keeps `ConsumerCount` thread-safe and non-negative.

### Tests

- Added regression coverage for the public consumer lifecycle methods.
- Added thread-safety coverage for repeated concurrent add/remove calls.
- Ran `dotnet test Emby.Xtream.Plugin.Tests/Emby.Xtream.Plugin.Tests.csproj --no-restore --verbosity minimal`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved live stream consumer tracking with a thread-safe `ConsumerCount` that never drops below zero.
  * Updated consumer add/remove handling to behave correctly under concurrent operations.
  * Ensured live stream exposes the required public consumer lifecycle methods for compatibility expectations.

* **Tests**
  * Added unit tests covering consumer add/remove lifecycle behavior, including multithreaded stress scenarios.
  * Added assertions that consumer counts return to zero after removals and that compatibility method availability is as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->