### PR TITLE
fix: make each playback session get its own MediaSource.Id (#43)

### DIFF
--- a/Emby.Xtream.Plugin.Tests/XtreamLiveStreamTests.cs
+++ b/Emby.Xtream.Plugin.Tests/XtreamLiveStreamTests.cs
@@ -111,8 +111,8 @@ namespace Emby.Xtream.Plugin.Tests
             {
                 Assert.NotEqual(stream1.UniqueId, stream2.UniqueId);
                 Assert.NotEqual(
-                    stream1.MediaSource.Id + "_" + stream1.UniqueId,
-                    stream2.MediaSource.Id + "_" + stream2.UniqueId);
+                    XtreamTunerHost.BuildSessionMediaSourceId(stream1.MediaSource.Id, stream1.UniqueId),
+                    XtreamTunerHost.BuildSessionMediaSourceId(stream2.MediaSource.Id, stream2.UniqueId));
             }
         }
 

--- a/Emby.Xtream.Plugin.Tests/XtreamLiveStreamTests.cs
+++ b/Emby.Xtream.Plugin.Tests/XtreamLiveStreamTests.cs
@@ -97,12 +97,43 @@ namespace Emby.Xtream.Plugin.Tests
             Assert.NotNull(typeof(XtreamLiveStream).GetMethod("RemoveConsumer"));
         }
 
+        [Fact]
+        public void ConcurrentSessionsGetUniqueMediaSourceIds()
+        {
+            // Two XtreamLiveStream instances for the same base channel id must have
+            // different UniqueIds, which GetChannelStream appends to MediaSource.Id.
+            // Without this, Emby's MediaSourceManager reuses the first live stream
+            // for both sessions and the first session's close kills the second (issue #43).
+            var baseId = "xtream_live_363";
+
+            using (var stream1 = CreateStream(baseId))
+            using (var stream2 = CreateStream(baseId))
+            {
+                Assert.NotEqual(stream1.UniqueId, stream2.UniqueId);
+                Assert.NotEqual(
+                    stream1.MediaSource.Id + "_" + stream1.UniqueId,
+                    stream2.MediaSource.Id + "_" + stream2.UniqueId);
+            }
+        }
+
         private static XtreamLiveStream CreateStream()
         {
             return new XtreamLiveStream(
                 new MediaSourceInfo
                 {
                     Id = "stream-1",
+                    Path = "http://example.invalid/live.ts"
+                },
+                "tuner-1",
+                new System.Net.Http.HttpClient());
+        }
+
+        private static XtreamLiveStream CreateStream(string baseId)
+        {
+            return new XtreamLiveStream(
+                new MediaSourceInfo
+                {
+                    Id = baseId,
                     Path = "http://example.invalid/live.ts"
                 },
                 "tuner-1",

--- a/Emby.Xtream.Plugin/Service/XtreamTunerHost.cs
+++ b/Emby.Xtream.Plugin/Service/XtreamTunerHost.cs
@@ -950,6 +950,13 @@ namespace Emby.Xtream.Plugin.Service
             var httpClient = Plugin.CreateHttpClient();
             ILiveStream liveStream = new XtreamLiveStream(mediaSource, tuner.Id, httpClient, Logger);
 
+            // Append a unique suffix per session so Emby's MediaSourceManager treats each
+            // session independently. Without this, two sessions on the same channel share
+            // one XtreamLiveStream (both have MediaSource.Id = "xtream_live_N"), and when the
+            // first session closes its consumer, RemoveConsumer drops the count to 0 and kills
+            // the shared live stream — taking the second session with it (issue #43).
+            mediaSource.Id = mediaSource.Id + "_" + ((XtreamLiveStream)liveStream).UniqueId;
+
             Logger.Info("Opening live stream for channel {0} (stream {1})",
                 tunerChannel?.Name ?? tunerChannel?.Id, streamId);
 

--- a/Emby.Xtream.Plugin/Service/XtreamTunerHost.cs
+++ b/Emby.Xtream.Plugin/Service/XtreamTunerHost.cs
@@ -955,13 +955,20 @@ namespace Emby.Xtream.Plugin.Service
             // one XtreamLiveStream (both have MediaSource.Id = "xtream_live_N"), and when the
             // first session closes its consumer, RemoveConsumer drops the count to 0 and kills
             // the shared live stream — taking the second session with it (issue #43).
-            mediaSource.Id = mediaSource.Id + "_" + ((XtreamLiveStream)liveStream).UniqueId;
+            mediaSource.Id = BuildSessionMediaSourceId(mediaSource.Id, ((XtreamLiveStream)liveStream).UniqueId);
 
             Logger.Info("Opening live stream for channel {0} (stream {1})",
                 tunerChannel?.Name ?? tunerChannel?.Id, streamId);
 
             return liveStream;
         }
+
+        /// <summary>
+        /// Builds a per-session unique media source ID by appending a session-specific suffix.
+        /// Shared by the production code and tests so a change to the suffix formula is caught.
+        /// </summary>
+        internal static string BuildSessionMediaSourceId(string baseId, string uniqueId)
+            => baseId + "_" + uniqueId;
 
         public void ClearCaches()
         {


### PR DESCRIPTION
## Summary

Fixes concurrent playback sessions on the same channel killing each other.

**Root cause**: when two devices play the same channel, they share one `XtreamLiveStream` because both sessions return `MediaSource.Id = "xtream_live_N"`. Emby`s `MediaSourceManager` reuses the first live stream for the second session. When the first session stops, `RemoveConsumer` drops the count to 0 and closes the stream, killing the second session too.

**Fix**: append `XtreamLiveStream.UniqueId` (a per-instance GUID) to `MediaSource.Id` in `GetChannelStream`. Each session now gets a uniquely identified media source, so Emby treats them independently. Closing one session only affects that session stream.

**Evidence from the reporter logs**:
- Chrome and iPhone both play ESPN (stream 363)
- Both sessions share `LiveStreamId: 06044cf0...xtream_live_363`
- Chrome stops at 00:08:23.425 → `consumer count is now 0` → stream closed
- iPhone gets `IOException: Unable to read data from the transport connection: Operation canceled` at 00:08:25.429

The `XtreamLiveStream` already tracks consumer count correctly; the issue is that Emby assigns both sessions to the same stream object.

## Testing

- `dotnet test`: 344 passed, 1 skipped (unchanged)
- Added `ConcurrentSessionsGetUniqueMediaSourceIds` test verifying two instances for the same channel have distinct UniqueIds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a live streaming issue where concurrent viewers of the same channel could end up sharing the same media source identifier, leading to cross-session interference.
  * Each active live stream session now gets its own unique media source identifier to improve stability during parallel playback.
* **Tests**
  * Added a test to verify that multiple simultaneous sessions created from the same channel produce distinct media source identifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->