### PR TITLE
ci: replace softprops/action-gh-release with gh CLI to fail loudly on missing DLL

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,9 +48,12 @@ jobs:
             fi
           } > release_notes.md
 
-      - name: Create draft release
-        uses: softprops/action-gh-release@v2
-        with:
-          files: Emby.Xtream.Plugin/out/Emby.Xtream.Plugin.dll
-          body_path: release_notes.md
-          draft: true
+      - name: Create release
+        run: |
+          gh release create "$GITHUB_REF_NAME" \
+            Emby.Xtream.Plugin/out/Emby.Xtream.Plugin.dll \
+            --title "$GITHUB_REF_NAME" \
+            --notes-file release_notes.md \
+            --prerelease
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Replaces softprops/action-gh-release@v2 with gh release create.
Fails loudly when DLL is missing. No moving tag, no draft:true surprises.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release publishing process to create prerelease builds with the included release notes and packaged plugin file.
  * Release titles now match the published tag name for clearer versioning.
  * Replaced the previous draft-release flow with a streamlined publishing step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->