### PR TITLE
Stop per-item exclusion from deleting user-owned folders

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,7 +80,9 @@ Xtream providers type the same field differently across (and within) servers: a 
 
 ### Per-item exclusions delete folders directly, not via orphan cleanup
 
-`ExcludedVodStreamIds` / `ExcludedSeriesIds` remove an item's folder in a targeted pass (`StrmSyncService.RemoveExcludedContent`) that ignores both `CleanupOrphans` and `OrphanSafetyThreshold`. That threshold guards against a provider returning a truncated catalogue; an exclusion is a deliberate user action, so suppressing the delete would just read as the filter doing nothing. Folder matching strips `[tmdbid=…]`/`[tvdbid=…]` suffixes, so a title is found regardless of the metadata-ID naming settings in force when it was written.
+`ExcludedVodStreamIds` / `ExcludedSeriesIds` remove an item's files in a targeted pass (`StrmSyncService.RemoveExcludedContent`) that ignores both `CleanupOrphans` and `OrphanSafetyThreshold`. That threshold guards against a provider returning a truncated catalogue; an exclusion is a deliberate user action, so suppressing the delete would just read as the filter doing nothing. Folder matching strips `[tmdbid=…]`/`[tvdbid=…]` suffixes, so a title is found regardless of the metadata-ID naming settings in force when it was written.
+
+**Never recursively delete a matched folder.** Matching is by title only, so a match is not proof of ownership. The pass skips any matched folder containing no `.strm` (it wasn't written by us — a user's own `Ben-Hur` must survive excluding the provider's `Ben-Hur`), deletes only `.strm`/`.nfo`, then prunes what that emptied. Same contract as `CleanupOrphans`. The first implementation used `Directory.Delete(dir, recursive: true)` and could destroy user data.
 
 Both sync methods compute their delta watermark from the **unfiltered** catalogue — if the newest title happens to be excluded, the watermark must still advance past it or every later sync re-processes everything after it. Re-ticking a title needs no watermark reset: both smart-skip paths already guard on the folder existing. See [ADR-012](docs/decisions/012-per-item-content-exclusion.md).
 

--- a/Emby.Xtream.Plugin.Tests/SyncMoviesIntegrationTests.cs
+++ b/Emby.Xtream.Plugin.Tests/SyncMoviesIntegrationTests.cs
@@ -327,6 +327,60 @@ namespace Emby.Xtream.Plugin.Tests
             Assert.True(File.Exists(MovieStrmPath("Keep Me")));
         }
 
+        /// <summary>
+        /// A folder that matches an excluded title by name but holds no STRM was not written
+        /// by this plugin. Recursively deleting it would destroy user data (codex review of
+        /// PR #58, [P1]). Nothing in it may be touched.
+        /// </summary>
+        [Fact]
+        public async Task ExcludedMovie_FolderWithNoStrm_LeftCompletelyUntouched()
+        {
+            var config = DefaultConfig();
+            config.ExcludedVodStreamIds = new[] { 2 };
+
+            // A user's own folder that happens to share the provider's title.
+            var userDir = Path.Combine(TempDir.Path, "Movies", "Drop Me");
+            Directory.CreateDirectory(userDir);
+            var userFile = Path.Combine(userDir, "my-own-movie.mkv");
+            File.WriteAllText(userFile, "not written by the plugin");
+
+            RegisterVodStreams(VodStreamsJson(
+                VodStream(streamId: 2, name: "Drop Me", added: 1000)));
+
+            await MakeService().SyncMoviesAsync(config, None, SaveConfig);
+
+            Assert.True(Directory.Exists(userDir), "user folder must survive");
+            Assert.True(File.Exists(userFile), "user file must survive");
+        }
+
+        /// <summary>
+        /// When the folder IS plugin-written but the user has also put their own file in it,
+        /// remove the plugin's files and leave theirs, keeping the folder. Same semantics as
+        /// CleanupOrphans, which only ever deletes STRMs and prunes emptied directories.
+        /// </summary>
+        [Fact]
+        public async Task ExcludedMovie_FolderWithForeignFile_RemovesStrmKeepsRest()
+        {
+            var config = DefaultConfig();
+            config.ExcludedVodStreamIds = new[] { 2 };
+
+            var dir = Path.Combine(TempDir.Path, "Movies", "Drop Me");
+            Directory.CreateDirectory(dir);
+            var strm = Path.Combine(dir, "Drop Me.strm");
+            var poster = Path.Combine(dir, "poster.jpg");
+            File.WriteAllText(strm, "http://fake-xtream/movie/user/pass/2.mkv");
+            File.WriteAllText(poster, "user artwork");
+
+            RegisterVodStreams(VodStreamsJson(
+                VodStream(streamId: 2, name: "Drop Me", added: 1000)));
+
+            await MakeService().SyncMoviesAsync(config, None, SaveConfig);
+
+            Assert.False(File.Exists(strm), "plugin STRM should be removed");
+            Assert.True(File.Exists(poster), "user artwork must survive");
+            Assert.True(Directory.Exists(dir), "folder must survive because it still has content");
+        }
+
         [Fact]
         public async Task ExcludedMovie_FolderWithTmdbSuffix_Deleted()
         {

--- a/Emby.Xtream.Plugin/Configuration/Web/config.js
+++ b/Emby.Xtream.Plugin/Configuration/Web/config.js
@@ -4,6 +4,21 @@ function (BaseView, loading) {
 
     var pluginId = 'b7e3c4a1-9f2d-4e8b-a5c6-d1f0e2b3c4a5';
 
+    // Element.closest is missing on some of the older browsers Emby still serves this
+    // dashboard to. The per-title panels are re-rendered from innerHTML, so per-element
+    // listeners aren't an option and the delegated handlers need a reliable walk-up.
+    function closestByClass(el, className) {
+        while (el && el.nodeType === 1) {
+            if (el.classList
+                    ? el.classList.contains(className)
+                    : (' ' + el.className + ' ').indexOf(' ' + className + ' ') >= 0) {
+                return el;
+            }
+            el = el.parentNode;
+        }
+        return null;
+    }
+
     function View(view, params) {
         BaseView.apply(this, arguments);
 
@@ -197,7 +212,7 @@ function (BaseView, loading) {
             if (!listEl) return;
 
             listEl.addEventListener('click', function (e) {
-                var toggle = e.target.closest('.contentItemToggle');
+                var toggle = closestByClass(e.target, 'contentItemToggle');
                 if (toggle) {
                     e.preventDefault();
                     toggleContentItemPanel(
@@ -208,7 +223,7 @@ function (BaseView, loading) {
                     return;
                 }
 
-                var selectAll = e.target.closest('.contentItemSelectAll');
+                var selectAll = closestByClass(e.target, 'contentItemSelectAll');
                 if (selectAll) {
                     e.preventDefault();
                     toggleAllContentItems(
@@ -219,7 +234,7 @@ function (BaseView, loading) {
                     return;
                 }
 
-                var deselectAll = e.target.closest('.contentItemDeselectAll');
+                var deselectAll = closestByClass(e.target, 'contentItemDeselectAll');
                 if (deselectAll) {
                     e.preventDefault();
                     toggleAllContentItems(
@@ -231,7 +246,7 @@ function (BaseView, loading) {
             });
 
             listEl.addEventListener('change', function (e) {
-                var cb = e.target.closest('.contentItemCheckbox');
+                var cb = closestByClass(e.target, 'contentItemCheckbox');
                 if (!cb) return;
                 setContentExclusion(
                     self,
@@ -305,7 +320,7 @@ function (BaseView, loading) {
 
         // Danger zone toggles (event delegation on form)
         view.querySelector('.xtreamConfigForm').addEventListener('click', function (e) {
-            var header = e.target.closest('.danger-zone-header');
+            var header = closestByClass(e.target, 'danger-zone-header');
             if (!header) return;
             var zone = header.parentNode;
             zone.classList.toggle('open');

--- a/Emby.Xtream.Plugin/Service/StrmSyncService.cs
+++ b/Emby.Xtream.Plugin/Service/StrmSyncService.cs
@@ -1851,10 +1851,39 @@ namespace Emby.Xtream.Plugin.Service
 
                 try
                 {
-                    Directory.Delete(existingDir, true);
+                    // Ownership check: a folder holding no STRM was not written by this plugin.
+                    // Matching is by title alone, so without this a user's own "Ben-Hur" folder
+                    // would be destroyed by excluding the provider's "Ben-Hur".
+                    var strmFiles = Directory.GetFiles(existingDir, "*.strm", SearchOption.AllDirectories);
+                    if (strmFiles.Length == 0)
+                    {
+                        _logger.Debug(
+                            "Skipping '{0}' for excluded item '{1}': no STRM files, so this folder isn't ours",
+                            existingDir, sanitized);
+                        continue;
+                    }
+
+                    // Delete only what we wrote, then prune whatever that emptied. Anything the
+                    // user put alongside it survives, and so does the folder if it still holds
+                    // content. Same contract as CleanupOrphans.
+                    foreach (var file in Directory.GetFiles(existingDir, "*.*", SearchOption.AllDirectories))
+                    {
+                        var ext = Path.GetExtension(file);
+                        if (string.Equals(ext, ".strm", StringComparison.OrdinalIgnoreCase)
+                            || string.Equals(ext, ".nfo", StringComparison.OrdinalIgnoreCase))
+                        {
+                            File.Delete(file);
+                        }
+                    }
+
+                    var folderGone = TryPruneEmptyTree(existingDir);
                     dirIndex.Remove(sanitized);
                     removed++;
-                    _logger.Info("Removed excluded item folder: {0}", existingDir);
+                    _logger.Info(
+                        folderGone
+                            ? "Removed excluded item folder: {0}"
+                            : "Removed plugin files for excluded item, folder kept (still has other content): {0}",
+                        existingDir);
                 }
                 catch (Exception ex)
                 {
@@ -1867,7 +1896,35 @@ namespace Emby.Xtream.Plugin.Service
                 _logger.Info("Removed {0} folder(s) for explicitly excluded items under {1}", removed, rootFolder);
             }
 
+
             return removed;
+        }
+
+        /// <summary>
+        /// Deletes <paramref name="dir"/> and any subdirectory of it that is empty, deepest first.
+        /// Stops at the first level that still holds something.
+        /// </summary>
+        /// <param name="dir">The directory to prune.</param>
+        /// <returns>True if <paramref name="dir"/> itself was removed.</returns>
+        private static bool TryPruneEmptyTree(string dir)
+        {
+            if (!Directory.Exists(dir))
+            {
+                return true;
+            }
+
+            foreach (var sub in Directory.GetDirectories(dir))
+            {
+                TryPruneEmptyTree(sub);
+            }
+
+            if (Directory.GetFileSystemEntries(dir).Length == 0)
+            {
+                Directory.Delete(dir);
+                return true;
+            }
+
+            return false;
         }
 
         private int CleanupOrphans(string rootPath, HashSet<string> validPaths, double safetyThreshold)

--- a/docs/decisions/012-per-item-content-exclusion.md
+++ b/docs/decisions/012-per-item-content-exclusion.md
@@ -84,6 +84,18 @@ Folder matching reuses the existing `StripFolderIdSuffix`, so a title is found w
 as `Some Movie`, `Some Movie [tmdbid=123]` or `Some Show [tvdbid=456]`. This keeps removal correct
 across changes to the metadata-ID naming settings.
 
+**Removal deletes files, not folders.** Matching is by title alone, so a matched folder is not
+necessarily ours. The pass therefore:
+
+1. Skips any matched folder containing no `.strm` at all — that folder was not written by this
+   plugin, and a user's own `Ben-Hur` directory must survive excluding the provider's `Ben-Hur`.
+2. Deletes only `.strm` and `.nfo` files inside it, then prunes whatever that emptied.
+
+Anything the user placed alongside our files survives, and the folder itself survives if it still
+holds content. This is the same contract `CleanupOrphans` has always had. The first implementation
+called `Directory.Delete(dir, recursive: true)` on a name match, which an independent review
+correctly flagged as capable of destroying user data.
+
 Two read-only endpoints (`GET /XtreamTuner/Items/Vod` and `/XtreamTuner/Items/Series`) return
 `{Id, Name}` for one category. The config UI calls them lazily when a category row is expanded.
 
@@ -107,3 +119,9 @@ Two read-only endpoints (`GET /XtreamTuner/Items/Vod` and `/XtreamTuner/Items/Se
   provider field would otherwise blank an entire category listing.
 - **The literal "don't re-add what I deleted on disk" ask is not covered.** Users must untick the title
   in config. This is a deliberate trade against the silent-suppression risk in Alternative 1.
+- **A renamed title leaves its old folder behind.** Exclusion is by ID, but the folder is located by
+  the item's *current* cleaned title. If the provider renames a title, or the user changes the
+  name-cleaning terms or the category-to-folder mapping after it was written, the old directory no
+  longer matches and stays until orphan cleanup reaches it. Accepted rather than fixed: a stable fix
+  needs an ownership marker written into every item folder plus a migration for existing libraries,
+  and the consequence here is a stale folder, not lost data.


### PR DESCRIPTION
Follow-up to #58, from an independent codex review of that PR. One critical finding, one advisory.

## The critical one

`RemoveExcludedContent` located a folder by title and then called `Directory.Delete(dir, recursive: true)`.

A title match is not proof of ownership. If a user keeps their own `Movies/Ben-Hur/` alongside the STRM library and excludes the provider's "Ben-Hur", the plugin deleted that folder and everything in it.

That is also more destructive than `CleanupOrphans`, which has only ever deleted `.strm` files and pruned the directories those emptied. The new code introduced a harsher deletion path without justifying it.

Removal now follows the same contract:

1. Skip any matched folder holding no `.strm` — it wasn't written by this plugin.
2. Delete only `.strm` and `.nfo`, then prune whatever that emptied.

Files the user placed alongside ours survive, and the folder survives if it still holds content. Behaviour for folders that only ever held our files is unchanged: they still disappear.

Rejected the reviewer's suggested fix (write an ownership marker containing the source ID into each folder) because it needs a new sidecar file plus a migration for every existing library, to solve a case that the STRM check already covers.

## The advisory one

The delegated config handlers used `Element.closest`, which is absent on some older browsers Emby serves the dashboard to. There the per-title expander silently did nothing. Replaced with a class walk-up helper, which also fixes one pre-existing use in the danger-zone header.

## Knowingly not fixed

If a provider renames a title, or the user changes name-cleaning terms or the folder mapping after it was written, the old folder no longer matches and is left behind for orphan cleanup. Fixing it properly needs the ownership marker above. The consequence is a stale folder, not lost data. Documented in ADR-012.

## Testing

358 tests pass. Two new ones cover the finding directly: a name-matched folder with no STRM must be untouched, and a folder holding both our STRM and a user file must lose only the STRM. Both fail against the previous implementation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved excluded-content cleanup to avoid deleting entire folders.
  * Preserves user-created files and subfolders while removing only plugin-generated media metadata.
  * Skips folders that do not contain supported stream files.
  * Automatically removes empty directories left after cleanup.
  * Improved configuration controls for compatibility with older browsers.
* **Tests**
  * Added coverage for preserving user files and non-empty folders during synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->