### PR TITLE
Stop sync and exclusion paths from deleting files the plugin did not write

### DIFF
--- a/Emby.Xtream.Plugin.Tests/ConcurrentSyncGuardTests.cs
+++ b/Emby.Xtream.Plugin.Tests/ConcurrentSyncGuardTests.cs
@@ -110,6 +110,34 @@ namespace Emby.Xtream.Plugin.Tests
         }
 
         [Fact]
+        public async Task RetryWithCancelledToken_DoesNotLeakTheMovieGate()
+        {
+            // Acquiring the series gate throws on a cancelled token. If that happens outside the
+            // try, the movie gate is never released and every later movie sync is refused until
+            // Emby restarts.
+            var config = DefaultConfig();
+            Handler.RespondWith("get_vod_streams",
+                VodStreamsJson(VodStream(streamId: 1, name: "Test Movie", added: 1000)));
+
+            var service = MakeService();
+            using (var cts = new System.Threading.CancellationTokenSource())
+            {
+                cts.Cancel();
+                try
+                {
+                    await service.RetryFailedAsync(cts.Token);
+                }
+                catch (System.OperationCanceledException)
+                {
+                    // Expected on a cancelled token; the gate must still be free.
+                }
+            }
+
+            Assert.True(await service.SyncMoviesAsync(config, None, SaveConfig),
+                "The movie gate must be free after a cancelled retry");
+        }
+
+        [Fact]
         public async Task RejectedSync_DoesNotClobberRunningSyncProgress()
         {
             var config = DefaultConfig();

--- a/Emby.Xtream.Plugin.Tests/ConcurrentSyncGuardTests.cs
+++ b/Emby.Xtream.Plugin.Tests/ConcurrentSyncGuardTests.cs
@@ -1,0 +1,130 @@
+using System.IO;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Emby.Xtream.Plugin.Tests
+{
+    /// <summary>
+    /// Tests for the single-flight sync gate.
+    ///
+    /// The callers' <c>IsRunning</c> check is a fast path, not a lock: between that check and the
+    /// point where the service marks itself running, a second request or the scheduled task could
+    /// pass it too. Two runs then shared the written-path set and the progress object, and whichever
+    /// finished first cleared <c>IsRunning</c> while the other was still writing.
+    /// </summary>
+    public class ConcurrentSyncGuardTests : SyncTestBase
+    {
+        [Fact]
+        public async Task ConcurrentMovieSyncs_OnlyOneRuns()
+        {
+            var config = DefaultConfig();
+            Handler.RespondWith("get_vod_streams",
+                VodStreamsJson(VodStream(streamId: 1, name: "Test Movie", added: 1000)));
+
+            var service = MakeService();
+
+            // Hold the first sync inside its HTTP call so the two are genuinely in flight at
+            // once. Without this the fake responds synchronously and the first run completes
+            // before the second even starts, which tests nothing.
+            Handler.Gate = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            // Start both without awaiting the first, so they overlap the way a manual sync and the
+            // scheduled task do.
+            var first = service.SyncMoviesAsync(config, None, SaveConfig);
+            var second = service.SyncMoviesAsync(config, None, SaveConfig);
+
+            Handler.Gate.SetResult(true);
+            var results = await Task.WhenAll(first, second);
+
+            Assert.Equal(1, System.Array.FindAll(results, r => r).Length);
+            Assert.Equal(1, System.Array.FindAll(results, r => !r).Length);
+        }
+
+        [Fact]
+        public async Task ConcurrentSeriesSyncs_OnlyOneRuns()
+        {
+            var config = DefaultConfig();
+            Handler.RespondWith("get_series", SeriesListJson(Series(seriesId: 1, name: "Test Show")));
+            Handler.RespondWith("get_series_info", SeriesDetailJson(seriesId: 1));
+
+            var service = MakeService();
+
+            // Hold the first sync inside its HTTP call so the two are genuinely in flight at
+            // once. Without this the fake responds synchronously and the first run completes
+            // before the second even starts, which tests nothing.
+            Handler.Gate = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            var first = service.SyncSeriesAsync(config, None, SaveConfig);
+            var second = service.SyncSeriesAsync(config, None, SaveConfig);
+
+            Handler.Gate.SetResult(true);
+            var results = await Task.WhenAll(first, second);
+
+            Assert.Equal(1, System.Array.FindAll(results, r => r).Length);
+            Assert.Equal(1, System.Array.FindAll(results, r => !r).Length);
+        }
+
+        [Fact]
+        public async Task GateIsReleased_SecondSyncAfterFirstCompletes_Runs()
+        {
+            var config = DefaultConfig();
+            Handler.RespondWithSequence("get_vod_streams", new[]
+            {
+                VodStreamsJson(VodStream(streamId: 1, name: "First Movie", added: 1000)),
+                VodStreamsJson(VodStream(streamId: 2, name: "Second Movie", added: 2000)),
+            });
+
+            var service = MakeService();
+
+            Assert.True(await service.SyncMoviesAsync(config, None, SaveConfig));
+            Assert.True(await service.SyncMoviesAsync(config, None, SaveConfig),
+                "The gate must be released once a sync finishes, or every later sync is blocked");
+
+            Assert.True(File.Exists(Path.Combine(TempDir.Path, "Movies", "Second Movie", "Second Movie.strm")));
+        }
+
+        [Fact]
+        public async Task MovieAndSeriesSyncs_RunConcurrently()
+        {
+            // Separate gates on purpose: they write to different roots and are meant to overlap.
+            var config = DefaultConfig();
+            Handler.RespondWith("get_vod_streams",
+                VodStreamsJson(VodStream(streamId: 1, name: "Test Movie", added: 1000)));
+            Handler.RespondWith("get_series", SeriesListJson(Series(seriesId: 1, name: "Test Show")));
+            Handler.RespondWith("get_series_info", SeriesDetailJson(seriesId: 1));
+
+            var service = MakeService();
+
+            var movies = service.SyncMoviesAsync(config, None, SaveConfig);
+            var series = service.SyncSeriesAsync(config, None, SaveConfig);
+
+            Assert.True(await movies);
+            Assert.True(await series);
+        }
+
+        [Fact]
+        public async Task RejectedSync_DoesNotClobberRunningSyncProgress()
+        {
+            var config = DefaultConfig();
+            Handler.RespondWith("get_vod_streams",
+                VodStreamsJson(VodStream(streamId: 1, name: "Test Movie", added: 1000)));
+
+            var service = MakeService();
+
+            // Hold the first sync inside its HTTP call so the two are genuinely in flight at
+            // once. Without this the fake responds synchronously and the first run completes
+            // before the second even starts, which tests nothing.
+            Handler.Gate = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            var first = service.SyncMoviesAsync(config, None, SaveConfig);
+            var second = service.SyncMoviesAsync(config, None, SaveConfig);
+
+            Handler.Gate.SetResult(true);
+            await Task.WhenAll(first, second);
+
+            // The rejected call must not have replaced the progress object or reset its counters.
+            Assert.Equal(1, service.MovieProgress.Total);
+            Assert.False(service.MovieProgress.IsRunning);
+        }
+    }
+}

--- a/Emby.Xtream.Plugin.Tests/ConcurrentSyncGuardTests.cs
+++ b/Emby.Xtream.Plugin.Tests/ConcurrentSyncGuardTests.cs
@@ -36,8 +36,8 @@ namespace Emby.Xtream.Plugin.Tests
             Handler.Gate.SetResult(true);
             var results = await Task.WhenAll(first, second);
 
-            Assert.Equal(1, System.Array.FindAll(results, r => r).Length);
-            Assert.Equal(1, System.Array.FindAll(results, r => !r).Length);
+            Assert.Single(results, r => r);
+            Assert.Single(results, r => !r);
         }
 
         [Fact]
@@ -60,8 +60,8 @@ namespace Emby.Xtream.Plugin.Tests
             Handler.Gate.SetResult(true);
             var results = await Task.WhenAll(first, second);
 
-            Assert.Equal(1, System.Array.FindAll(results, r => r).Length);
-            Assert.Equal(1, System.Array.FindAll(results, r => !r).Length);
+            Assert.Single(results, r => r);
+            Assert.Single(results, r => !r);
         }
 
         [Fact]

--- a/Emby.Xtream.Plugin.Tests/ConcurrentSyncGuardTests.cs
+++ b/Emby.Xtream.Plugin.Tests/ConcurrentSyncGuardTests.cs
@@ -95,11 +95,18 @@ namespace Emby.Xtream.Plugin.Tests
 
             var service = MakeService();
 
+            // Hold both in flight at once. Without this they run one after the other and the test
+            // would pass even if movies and series shared a single gate, which is the thing it is
+            // supposed to rule out.
+            Handler.Gate = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
             var movies = service.SyncMoviesAsync(config, None, SaveConfig);
             var series = service.SyncSeriesAsync(config, None, SaveConfig);
 
+            Handler.Gate.SetResult(true);
+
             Assert.True(await movies);
-            Assert.True(await series);
+            Assert.True(await series, "Series sync must not be blocked by an in-flight movie sync");
         }
 
         [Fact]

--- a/Emby.Xtream.Plugin.Tests/ConfigValidationTests.cs
+++ b/Emby.Xtream.Plugin.Tests/ConfigValidationTests.cs
@@ -1,0 +1,119 @@
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Emby.Xtream.Plugin.Service;
+using Xunit;
+
+namespace Emby.Xtream.Plugin.Tests
+{
+    /// <summary>
+    /// Tests for values that reach the service from persisted configuration rather than from the
+    /// config UI, which is the only thing that validates them today.
+    /// </summary>
+    public class ConfigValidationTests : SyncTestBase
+    {
+        // -----------------------------------------------------------------
+        // SyncParallelism
+        // -----------------------------------------------------------------
+
+        [Theory]
+        [InlineData(0, 1)]      // the dangerous one: a semaphore with no permits never releases
+        [InlineData(-5, 1)]
+        [InlineData(1, 1)]
+        [InlineData(3, 3)]
+        [InlineData(10, 10)]
+        [InlineData(50, 10)]
+        [InlineData(int.MaxValue, 10)]
+        public void GetSyncParallelism_ClampsToUsableRange(int configured, int expected)
+        {
+            var config = DefaultConfig();
+            config.SyncParallelism = configured;
+
+            Assert.Equal(expected, StrmSyncService.GetSyncParallelism(config));
+        }
+
+        [Fact]
+        public async Task ZeroParallelism_SyncStillCompletes()
+        {
+            // Unclamped this constructs SemaphoreSlim(0): the first task waits forever, the sync
+            // hangs, and the scheduled task never releases. Recovery meant hand-editing the XML.
+            var config = DefaultConfig();
+            config.SyncParallelism = 0;
+
+            Handler.RespondWith("get_vod_streams",
+                VodStreamsJson(VodStream(streamId: 1, name: "Test Movie", added: 1000)));
+
+            var sync = MakeService().SyncMoviesAsync(config, None, SaveConfig);
+            var finished = await Task.WhenAny(sync, Task.Delay(5000));
+
+            Assert.Same(sync, finished);
+            Assert.True(File.Exists(Path.Combine(TempDir.Path, "Movies", "Test Movie", "Test Movie.strm")));
+        }
+
+        // -----------------------------------------------------------------
+        // Credentials in URL path segments
+        // -----------------------------------------------------------------
+
+        [Fact]
+        public async Task CredentialsWithSpecialCharacters_AreEscapedInStrmUrl()
+        {
+            // A password containing '/' or '?' silently produced a broken playback URL: the extra
+            // separator changed which path segment the provider saw, and '#' truncated everything
+            // after it into a fragment.
+            var config = DefaultConfig();
+            config.Username = "user name";
+            config.Password = "p/a?ss#w d";
+
+            Handler.RespondWith("get_vod_streams",
+                VodStreamsJson(VodStream(streamId: 42, name: "Test Movie", added: 1000, ext: "mkv")));
+
+            await MakeService().SyncMoviesAsync(config, None, SaveConfig);
+
+            var strm = Path.Combine(TempDir.Path, "Movies", "Test Movie", "Test Movie.strm");
+            var url = File.ReadAllText(strm);
+
+            Assert.Equal("http://fake-xtream/movie/user%20name/p%2Fa%3Fss%23w%20d/42.mkv", url);
+
+            // The stream id must still be the last path segment, which is what breaks without this.
+            Assert.EndsWith("/42.mkv", url);
+            Assert.Equal(5, new System.Uri(url).Segments.Length);
+        }
+
+        [Fact]
+        public async Task PlainCredentials_UrlIsUnchanged()
+        {
+            // Escaping is a no-op for ordinary credentials, so existing STRM files are not rewritten
+            // and no library re-scan is triggered on upgrade.
+            var config = DefaultConfig();
+
+            Handler.RespondWith("get_vod_streams",
+                VodStreamsJson(VodStream(streamId: 42, name: "Test Movie", added: 1000, ext: "mkv")));
+
+            await MakeService().SyncMoviesAsync(config, None, SaveConfig);
+
+            var url = File.ReadAllText(Path.Combine(TempDir.Path, "Movies", "Test Movie", "Test Movie.strm"));
+            Assert.Equal("http://fake-xtream/movie/user/pass/42.mkv", url);
+        }
+
+        [Fact]
+        public async Task CredentialsWithSpecialCharacters_AreEscapedInSeriesStrmUrl()
+        {
+            var config = DefaultConfig();
+            config.Username = "us er";
+            config.Password = "p/w";
+
+            Handler.RespondWith("get_series", SeriesListJson(Series(seriesId: 1, name: "Test Show")));
+            Handler.RespondWith("get_series_info", SeriesDetailJson(seriesId: 1, ext: "mp4"));
+
+            await MakeService().SyncSeriesAsync(config, None, SaveConfig);
+
+            var strm = Directory
+                .GetFiles(Path.Combine(TempDir.Path, "Shows"), "*.strm", SearchOption.AllDirectories)
+                .Single();
+            var url = File.ReadAllText(strm);
+
+            Assert.Contains("/us%20er/p%2Fw/", url);
+            Assert.EndsWith(".mp4", url);
+        }
+    }
+}

--- a/Emby.Xtream.Plugin.Tests/Fakes/FakeHttpHandler.cs
+++ b/Emby.Xtream.Plugin.Tests/Fakes/FakeHttpHandler.cs
@@ -20,6 +20,16 @@ namespace Emby.Xtream.Plugin.Tests.Fakes
 
         public List<string> ReceivedUrls { get; } = new List<string>();
 
+        /// <summary>
+        /// Optional gate. When set, every request waits on it before responding.
+        /// </summary>
+        /// <remarks>
+        /// Responses are otherwise produced synchronously, so a caller runs to completion before it
+        /// ever returns its Task. That makes it impossible to hold two calls genuinely in flight,
+        /// which is exactly what a concurrency test needs. Complete this to let requests through.
+        /// </remarks>
+        public TaskCompletionSource<bool> Gate { get; set; }
+
         /// <summary>Register a single response for URLs containing <paramref name="urlSubstring"/>.</summary>
         public void RespondWith(string urlSubstring, string body, HttpStatusCode status = HttpStatusCode.OK)
         {
@@ -37,21 +47,26 @@ namespace Emby.Xtream.Plugin.Tests.Fakes
             _rules.Add((urlSubstring, q));
         }
 
-        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
+            var gate = Gate;
+            if (gate != null)
+            {
+                await gate.Task.ConfigureAwait(false);
+            }
+
             var url = request.RequestUri?.ToString() ?? string.Empty;
-            ReceivedUrls.Add(url);
+            lock (ReceivedUrls) { ReceivedUrls.Add(url); }
 
             foreach (var (urlSubstring, queue) in _rules)
             {
                 if (url.Contains(urlSubstring) && queue.Count > 0)
                 {
                     var (body, status) = queue.Dequeue();
-                    var response = new HttpResponseMessage(status)
+                    return new HttpResponseMessage(status)
                     {
                         Content = new StringContent(body, Encoding.UTF8, "application/json")
                     };
-                    return Task.FromResult(response);
                 }
             }
 

--- a/Emby.Xtream.Plugin.Tests/Fakes/FakeHttpHandler.cs
+++ b/Emby.Xtream.Plugin.Tests/Fakes/FakeHttpHandler.cs
@@ -18,6 +18,9 @@ namespace Emby.Xtream.Plugin.Tests.Fakes
         private readonly List<(string UrlSubstring, Queue<(string Body, HttpStatusCode Status)> Responses)> _rules
             = new List<(string, Queue<(string, HttpStatusCode)>)>();
 
+        /// <summary>Guards _rules, its queues, and ReceivedUrls.</summary>
+        private readonly object _sync = new object();
+
         public List<string> ReceivedUrls { get; } = new List<string>();
 
         /// <summary>
@@ -35,7 +38,7 @@ namespace Emby.Xtream.Plugin.Tests.Fakes
         {
             var q = new Queue<(string, HttpStatusCode)>();
             q.Enqueue((body, status));
-            _rules.Add((urlSubstring, q));
+            lock (_sync) { _rules.Add((urlSubstring, q)); }
         }
 
         /// <summary>Register multiple ordered responses for the same URL pattern.</summary>
@@ -44,7 +47,7 @@ namespace Emby.Xtream.Plugin.Tests.Fakes
             var q = new Queue<(string, HttpStatusCode)>();
             foreach (var b in bodies)
                 q.Enqueue((b, status));
-            _rules.Add((urlSubstring, q));
+            lock (_sync) { _rules.Add((urlSubstring, q)); }
         }
 
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
@@ -56,17 +59,24 @@ namespace Emby.Xtream.Plugin.Tests.Fakes
             }
 
             var url = request.RequestUri?.ToString() ?? string.Empty;
-            lock (ReceivedUrls) { ReceivedUrls.Add(url); }
 
-            foreach (var (urlSubstring, queue) in _rules)
+            // One lock over all shared state. Releasing the gate resumes several requests at once
+            // on thread-pool threads, and Queue<T> is not thread-safe: concurrent dequeues can
+            // hand back the wrong body or throw.
+            lock (_sync)
             {
-                if (url.Contains(urlSubstring) && queue.Count > 0)
+                ReceivedUrls.Add(url);
+
+                foreach (var (urlSubstring, queue) in _rules)
                 {
-                    var (body, status) = queue.Dequeue();
-                    return new HttpResponseMessage(status)
+                    if (url.Contains(urlSubstring) && queue.Count > 0)
                     {
-                        Content = new StringContent(body, Encoding.UTF8, "application/json")
-                    };
+                        var (body, status) = queue.Dequeue();
+                        return new HttpResponseMessage(status)
+                        {
+                            Content = new StringContent(body, Encoding.UTF8, "application/json")
+                        };
+                    }
                 }
             }
 

--- a/Emby.Xtream.Plugin.Tests/LogSanitizerTests.cs
+++ b/Emby.Xtream.Plugin.Tests/LogSanitizerTests.cs
@@ -43,6 +43,30 @@ namespace Emby.Xtream.Plugin.Tests
         }
 
         [Fact]
+        public void ShortCredentialCannotSplitAnotherCredentialsEscapedForm()
+        {
+            // "%20" lands inside the escaped form of "p q" ("p%20q"). Replacing one value at a
+            // time would split it, so the longer value stops matching and its readable characters
+            // survive. One pass over all forms, longest first, cannot do that.
+            var result = LogSanitizer.SanitizeLine(
+                "url http://h/movie/u/p%20q/1.mkv", "%20", "p q", "", "");
+
+            Assert.DoesNotContain("p%20q", result);
+            Assert.DoesNotContain("%20q", result);
+        }
+
+        [Fact]
+        public void RedactionMarkerIsNotRescannedByLaterValues()
+        {
+            // A credential that occurs inside the marker text must not chew up an earlier
+            // redaction. A single pass never revisits what it already replaced.
+            var result = LogSanitizer.SanitizeLine(
+                "user bob logged in", "bob", "redacted", "", "");
+
+            Assert.Contains("<redacted>", result);
+        }
+
+        [Fact]
         public void RedactsPercentEncodedCredentialsInUrls()
         {
             // Credentials go into generated URLs escaped, so the escaped form is what actually

--- a/Emby.Xtream.Plugin.Tests/LogSanitizerTests.cs
+++ b/Emby.Xtream.Plugin.Tests/LogSanitizerTests.cs
@@ -22,6 +22,39 @@ namespace Emby.Xtream.Plugin.Tests
         }
 
         [Fact]
+        public void RedactsPercentEncodedCredentialsInUrls()
+        {
+            // Credentials go into generated URLs escaped, so the escaped form is what actually
+            // appears in a logged stream URL. Redacting only the raw form leaks it into the log a
+            // user attaches to a bug report.
+            var result = LogSanitizer.SanitizeLine(
+                "Playing http://host/movie/us%20er/p%2Fw/1.mkv", "us er", "p/w", "", "");
+
+            Assert.DoesNotContain("us%20er", result);
+            Assert.DoesNotContain("p%2Fw", result);
+        }
+
+        [Fact]
+        public void RedactsRawCredentialsEvenWhenEscapedFormDiffers()
+        {
+            // The raw form still has to go: not every log line is a URL.
+            var result = LogSanitizer.SanitizeLine(
+                "Configured account us er / p/w", "us er", "p/w", "", "");
+
+            Assert.DoesNotContain("us er", result);
+            Assert.DoesNotContain("p/w", result);
+        }
+
+        [Fact]
+        public void RedactsPercentEncodedDispatcharrCredentials()
+        {
+            var result = LogSanitizer.SanitizeLine(
+                "Dispatcharr auth for d%20user", "", "", "d user", "d pass");
+
+            Assert.DoesNotContain("d%20user", result);
+        }
+
+        [Fact]
         public void RedactsConfiguredUsername()
         {
             var result = LogSanitizer.SanitizeLine(

--- a/Emby.Xtream.Plugin.Tests/LogSanitizerTests.cs
+++ b/Emby.Xtream.Plugin.Tests/LogSanitizerTests.cs
@@ -60,10 +60,13 @@ namespace Emby.Xtream.Plugin.Tests
         {
             // A credential that occurs inside the marker text must not chew up an earlier
             // redaction. A single pass never revisits what it already replaced.
+            //
+            // Assert the whole line: a Contains check would also pass on "<<redacted>>", which is
+            // exactly the regression this test exists to catch.
             var result = LogSanitizer.SanitizeLine(
                 "user bob logged in", "bob", "redacted", "", "");
 
-            Assert.Contains("<redacted>", result);
+            Assert.Equal("user <redacted> logged in", result);
         }
 
         [Fact]

--- a/Emby.Xtream.Plugin.Tests/LogSanitizerTests.cs
+++ b/Emby.Xtream.Plugin.Tests/LogSanitizerTests.cs
@@ -22,6 +22,27 @@ namespace Emby.Xtream.Plugin.Tests
         }
 
         [Fact]
+        public void RedactsLongerCredentialBeforeShorterOverlappingOne()
+        {
+            // Username "abc" is a prefix of password "abc/secret". Redacting the short one first
+            // rewrites the long one out of existence before its own turn, and the "/secret" tail
+            // survives into the downloadable log.
+            var result = LogSanitizer.SanitizeLine(
+                "auth abc/secret here", "abc", "abc/secret", "", "");
+
+            Assert.DoesNotContain("secret", result);
+        }
+
+        [Fact]
+        public void RedactsLongerCredentialBeforeShorterOverlappingOne_EscapedForm()
+        {
+            var result = LogSanitizer.SanitizeLine(
+                "url http://h/movie/abc/abc%2Fsecret/1.mkv", "abc", "abc/secret", "", "");
+
+            Assert.DoesNotContain("secret", result);
+        }
+
+        [Fact]
         public void RedactsPercentEncodedCredentialsInUrls()
         {
             // Credentials go into generated URLs escaped, so the escaped form is what actually

--- a/Emby.Xtream.Plugin.Tests/PartialCatalogueCleanupTests.cs
+++ b/Emby.Xtream.Plugin.Tests/PartialCatalogueCleanupTests.cs
@@ -1,0 +1,233 @@
+using System.IO;
+using System.Net;
+using System.Threading.Tasks;
+using Emby.Xtream.Plugin.Service;
+using Xunit;
+
+namespace Emby.Xtream.Plugin.Tests
+{
+    /// <summary>
+    /// Regression tests for the "incomplete upstream data drives deletion" bug class.
+    ///
+    /// A per-category request that failed used to be swallowed into an empty list, which orphan
+    /// cleanup could not tell apart from a category that is genuinely empty, so it deleted that
+    /// category's existing files. Likewise an empty <c>get_series_info</c> payload looked like a
+    /// show that had lost every episode.
+    ///
+    /// Every test here starts with files ALREADY ON DISK and asserts they survive. A test that
+    /// starts from an empty directory passes trivially and proves nothing, which is exactly why
+    /// the pre-existing empty-response test missed this.
+    /// </summary>
+    public class PartialCatalogueCleanupTests : SyncTestBase
+    {
+        private string MovieStrmPath(string movieName)
+            => Path.Combine(TempDir.Path, "Movies", movieName, movieName + ".strm");
+
+        private string SeedMovieStrm(string movieName, string content = "http://fake-xtream/movie/user/pass/99.mkv")
+        {
+            var path = MovieStrmPath(movieName);
+            Directory.CreateDirectory(Path.GetDirectoryName(path));
+            File.WriteAllText(path, content);
+            return path;
+        }
+
+        private string SeedSeriesStrm(string showName, string season, string fileName,
+            string content = "http://fake-xtream/series/user/pass/99.mp4")
+        {
+            var path = Path.Combine(TempDir.Path, "Shows", showName, season, fileName);
+            Directory.CreateDirectory(Path.GetDirectoryName(path));
+            File.WriteAllText(path, content);
+            return path;
+        }
+
+        // -----------------------------------------------------------------
+        // Movies: one category 502s
+        // -----------------------------------------------------------------
+
+        [Fact]
+        public async Task MovieCategoryFetchFails_ExistingFilesForThatCategorySurvive()
+        {
+            var config = DefaultConfig();
+            config.CleanupOrphans = true;
+            config.SelectedVodCategoryIds = new[] { 1, 2 };
+
+            // Category 1 answers with one movie. Category 2 fails.
+            Handler.RespondWith("category_id=1", VodStreamsJson(VodStream(streamId: 1, name: "Kept Movie", added: 1000)));
+            Handler.RespondWith("category_id=2", "{}", HttpStatusCode.InternalServerError);
+
+            // A movie from the failed category is already on disk.
+            var strandedPath = SeedMovieStrm("Movie From Broken Category");
+
+            await MakeService().SyncMoviesAsync(config, None, SaveConfig);
+
+            Assert.True(File.Exists(strandedPath),
+                "A movie belonging to the category that failed must not be deleted as an orphan");
+            Assert.True(File.Exists(MovieStrmPath("Kept Movie")),
+                "The category that succeeded should still have been written");
+        }
+
+        [Fact]
+        public async Task MovieCategoryFetchFails_WatermarkStillAdvances()
+        {
+            var config = DefaultConfig();
+            config.SelectedVodCategoryIds = new[] { 1, 2 };
+
+            Handler.RespondWith("category_id=1", VodStreamsJson(VodStream(streamId: 1, name: "New Movie", added: 5000)));
+            Handler.RespondWith("category_id=2", "{}", HttpStatusCode.InternalServerError);
+
+            await MakeService().SyncMoviesAsync(config, None, SaveConfig);
+
+            // Freezing the watermark on a partial failure would make every later sync
+            // re-process the categories that did succeed.
+            Assert.Equal(5000, config.LastMovieSyncTimestamp);
+        }
+
+        [Fact]
+        public async Task AllMovieCategoriesSucceed_CleanupStillRuns()
+        {
+            var config = DefaultConfig();
+            config.CleanupOrphans = true;
+            config.SelectedVodCategoryIds = new[] { 1 };
+
+            Handler.RespondWith("category_id=1", VodStreamsJson(VodStream(streamId: 1, name: "Kept Movie", added: 1000)));
+
+            var orphanPath = SeedMovieStrm("Genuinely Removed Movie");
+
+            await MakeService().SyncMoviesAsync(config, None, SaveConfig);
+
+            Assert.False(File.Exists(orphanPath),
+                "With every category answering, a title the provider no longer lists is a real orphan");
+        }
+
+        // -----------------------------------------------------------------
+        // Series: one category 502s
+        // -----------------------------------------------------------------
+
+        [Fact]
+        public async Task SeriesCategoryFetchFails_ExistingEpisodesSurvive()
+        {
+            var config = DefaultConfig();
+            config.CleanupOrphans = true;
+            config.SelectedSeriesCategoryIds = new[] { 1, 2 };
+
+            Handler.RespondWith("get_series&category_id=1", SeriesListJson(Series(seriesId: 1, name: "Kept Show")));
+            Handler.RespondWith("get_series&category_id=2", "{}", HttpStatusCode.InternalServerError);
+            Handler.RespondWith("get_series_info", SeriesDetailJson(seriesId: 1));
+
+            var strandedPath = SeedSeriesStrm("Show From Broken Category", "Season 01", "S01E01.strm");
+
+            await MakeService().SyncSeriesAsync(config, None, SaveConfig);
+
+            Assert.True(File.Exists(strandedPath),
+                "Episodes of a show in the category that failed must not be deleted as orphans");
+        }
+
+        // -----------------------------------------------------------------
+        // Series: transient empty episode payload
+        // -----------------------------------------------------------------
+
+        [Fact]
+        public async Task SeriesReturnsNoEpisodes_ExistingEpisodesOnDiskSurvive()
+        {
+            var config = DefaultConfig();
+            config.CleanupOrphans = true;
+
+            Handler.RespondWith("get_series", SeriesListJson(Series(seriesId: 1, name: "Test Show")));
+            // Provider hiccups and reports the show with no episodes at all.
+            Handler.RespondWith("get_series_info",
+                "{\"info\":{\"series_id\":1,\"name\":\"Test Show\"},\"seasons\":[],\"episodes\":{}}");
+
+            var existingPath = SeedSeriesStrm("Test Show", "Season 01", "S01E01.strm");
+
+            await MakeService().SyncSeriesAsync(config, None, SaveConfig);
+
+            Assert.True(File.Exists(existingPath),
+                "A transient empty episode payload must not wipe a show that already has files");
+        }
+
+        [Fact]
+        public async Task SeriesReturnsNoEpisodes_AndHasNoFilesOnDisk_DoesNotBlockCleanup()
+        {
+            var config = DefaultConfig();
+            config.CleanupOrphans = true;
+
+            // One healthy show (so the run produces files and the empty-catalogue guard does not
+            // fire) plus one show that reports no episodes and owns nothing on disk.
+            Handler.RespondWith("get_series", SeriesListJson(
+                Series(seriesId: 1, name: "Good Show"),
+                Series(seriesId: 2, name: "Empty Show")));
+            Handler.RespondWith("series_id=1", SeriesDetailJson(seriesId: 1));
+            Handler.RespondWith("series_id=2",
+                "{\"info\":{\"series_id\":2,\"name\":\"Empty Show\"},\"seasons\":[],\"episodes\":{}}");
+
+            var orphanPath = SeedSeriesStrm("Removed Show", "Season 01", "S01E01.strm");
+
+            await MakeService().SyncSeriesAsync(config, None, SaveConfig);
+
+            Assert.False(File.Exists(orphanPath),
+                "A show that returns empty while owning nothing on disk is not a failure, so unrelated orphans are still cleaned");
+        }
+
+        [Fact]
+        public async Task EverySeriesReturnsEmpty_DeletesNothing()
+        {
+            // The catalogue is not empty, but nothing survived it. Deleting the whole library on
+            // the strength of that is the catastrophic case, so cleanup refuses.
+            var config = DefaultConfig();
+            config.CleanupOrphans = true;
+
+            Handler.RespondWith("get_series", SeriesListJson(Series(seriesId: 1, name: "Empty Show")));
+            Handler.RespondWith("get_series_info",
+                "{\"info\":{\"series_id\":1,\"name\":\"Empty Show\"},\"seasons\":[],\"episodes\":{}}");
+
+            var existingPath = SeedSeriesStrm("Removed Show", "Season 01", "S01E01.strm");
+
+            await MakeService().SyncSeriesAsync(config, None, SaveConfig);
+
+            Assert.True(File.Exists(existingPath),
+                "A run that produced no files at all must not be read as a library-wide deletion");
+        }
+
+        // -----------------------------------------------------------------
+        // Empty catalogue must never be read as a deletion
+        // -----------------------------------------------------------------
+
+        [Fact]
+        public async Task EmptyCatalogue_WithFilesOnDisk_DeletesNothing()
+        {
+            var config = DefaultConfig();
+            config.CleanupOrphans = true;
+            config.OrphanSafetyThreshold = 0.2;
+
+            // Provider returns a valid but empty catalogue.
+            Handler.RespondWith("get_vod_streams", "[]");
+
+            var a = SeedMovieStrm("Movie A");
+            var b = SeedMovieStrm("Movie B");
+
+            await MakeService().SyncMoviesAsync(config, None, SaveConfig);
+
+            Assert.True(File.Exists(a), "An empty catalogue must not empty the library");
+            Assert.True(File.Exists(b), "An empty catalogue must not empty the library");
+        }
+
+        [Fact]
+        public async Task EmptyCatalogue_SmallLibrary_DeletesNothing()
+        {
+            // The ratio guard only applies above 10 files, so a small library had no protection
+            // at all. This is the case that could lose an entire modest collection.
+            var config = DefaultConfig();
+            config.CleanupOrphans = true;
+            config.OrphanSafetyThreshold = 0.2;
+
+            Handler.RespondWith("get_vod_streams", "[]");
+
+            var only = SeedMovieStrm("The Only Movie");
+
+            await MakeService().SyncMoviesAsync(config, None, SaveConfig);
+
+            Assert.True(File.Exists(only),
+                "A transient empty response must not delete the last file in a small library");
+        }
+    }
+}

--- a/Emby.Xtream.Plugin.Tests/StrmOwnershipTests.cs
+++ b/Emby.Xtream.Plugin.Tests/StrmOwnershipTests.cs
@@ -62,6 +62,22 @@ namespace Emby.Xtream.Plugin.Tests
         }
 
         [Fact]
+        public void IsOwnedStrm_HostPrefixWithoutPathBoundary_IsNotOwned()
+        {
+            // A bare prefix match means a BaseUrl of http://nas also claims the user's
+            // http://nas-backup/... file, and this class deletes what it claims.
+            var path = WriteFile(MovieDir("A"), "A.strm", "http://nas-backup/media/Movie.mkv");
+            Assert.False(StrmOwnership.IsOwnedStrm(path, "http://nas", null));
+        }
+
+        [Fact]
+        public void IsOwnedStrm_HostPrefixWithPathBoundary_IsOwned()
+        {
+            var path = WriteFile(MovieDir("B"), "B.strm", "http://nas/movie/user/pass/1.mkv");
+            Assert.True(StrmOwnership.IsOwnedStrm(path, "http://nas", null));
+        }
+
+        [Fact]
         public void IsOwnedStrm_EmptyFile_IsNotOwned()
         {
             var path = WriteFile(MovieDir("A"), "A.strm", "");

--- a/Emby.Xtream.Plugin.Tests/StrmOwnershipTests.cs
+++ b/Emby.Xtream.Plugin.Tests/StrmOwnershipTests.cs
@@ -1,0 +1,233 @@
+using System.IO;
+using System.Threading.Tasks;
+using Emby.Xtream.Plugin.Service;
+using Xunit;
+
+namespace Emby.Xtream.Plugin.Tests
+{
+    /// <summary>
+    /// Tests for content-based ownership verification (ADR-014).
+    ///
+    /// Both delete paths matched by title or by "is a .strm", neither of which proves the plugin
+    /// wrote the file. These tests seed files the plugin did NOT write and assert they survive.
+    /// </summary>
+    public class StrmOwnershipTests : SyncTestBase
+    {
+        private const string OwnedMovieUrl = "http://fake-xtream/movie/user/pass/42.mkv";
+        private const string ForeignUrl = "http://my-own-nas/media/Movie.mkv";
+
+        private string MovieDir(string name) => Path.Combine(TempDir.Path, "Movies", name);
+
+        private string WriteFile(string dir, string fileName, string content)
+        {
+            Directory.CreateDirectory(dir);
+            var path = Path.Combine(dir, fileName);
+            File.WriteAllText(path, content);
+            return path;
+        }
+
+        // -----------------------------------------------------------------
+        // Unit: IsOwnedStrm
+        // -----------------------------------------------------------------
+
+        [Fact]
+        public void IsOwnedStrm_ProviderUrl_IsOwned()
+        {
+            var path = WriteFile(MovieDir("A"), "A.strm", OwnedMovieUrl);
+            Assert.True(StrmOwnership.IsOwnedStrm(path, "http://fake-xtream", null));
+        }
+
+        [Fact]
+        public void IsOwnedStrm_TrailingSlashOnBaseUrl_StillOwned()
+        {
+            var path = WriteFile(MovieDir("A"), "A.strm", OwnedMovieUrl);
+            Assert.True(StrmOwnership.IsOwnedStrm(path, "http://fake-xtream/", null));
+        }
+
+        [Fact]
+        public void IsOwnedStrm_DispatcharrProxyUrl_IsOwned()
+        {
+            // Multi-version entries point at Dispatcharr, not at BaseUrl. Checking only BaseUrl
+            // would classify every multi-version STRM as foreign and stop cleaning them.
+            var path = WriteFile(MovieDir("A"), "A - Version 2.strm",
+                "http://dispatcharr:9191/proxy/vod/movie/abc-uuid?stream_id=7");
+            Assert.True(StrmOwnership.IsOwnedStrm(path, "http://fake-xtream", "http://dispatcharr:9191"));
+        }
+
+        [Fact]
+        public void IsOwnedStrm_ForeignUrl_IsNotOwned()
+        {
+            var path = WriteFile(MovieDir("A"), "A.strm", ForeignUrl);
+            Assert.False(StrmOwnership.IsOwnedStrm(path, "http://fake-xtream", null));
+        }
+
+        [Fact]
+        public void IsOwnedStrm_EmptyFile_IsNotOwned()
+        {
+            var path = WriteFile(MovieDir("A"), "A.strm", "");
+            Assert.False(StrmOwnership.IsOwnedStrm(path, "http://fake-xtream", null));
+        }
+
+        [Fact]
+        public void IsOwnedStrm_MissingFile_IsNotOwned()
+        {
+            var path = Path.Combine(MovieDir("Nope"), "Nope.strm");
+            Assert.False(StrmOwnership.IsOwnedStrm(path, "http://fake-xtream", null));
+        }
+
+        // -----------------------------------------------------------------
+        // Unit: DeleteOwnedFiles
+        // -----------------------------------------------------------------
+
+        [Fact]
+        public void DeleteOwnedFiles_LeavesForeignStrmAndNfo()
+        {
+            var dir = MovieDir("Mixed");
+            var ours = WriteFile(dir, "Mixed.strm", OwnedMovieUrl);
+            var ourNfo = WriteFile(dir, "Mixed.nfo", "<movie />");
+            var theirStrm = WriteFile(dir, "trailer.strm", ForeignUrl);
+            var theirNfo = WriteFile(dir, "my-notes.nfo", "hand written");
+
+            bool folderRemoved;
+            var deleted = StrmOwnership.DeleteOwnedFiles(dir, "http://fake-xtream", null, out folderRemoved);
+
+            Assert.Equal(2, deleted);
+            Assert.False(File.Exists(ours));
+            Assert.False(File.Exists(ourNfo));
+            Assert.True(File.Exists(theirStrm), "A user's own STRM beside our output must survive");
+            Assert.True(File.Exists(theirNfo), "A hand-written NFO must survive");
+            Assert.False(folderRemoved, "The folder still holds the user's files");
+        }
+
+        [Fact]
+        public void DeleteOwnedFiles_NothingOwned_DeletesNothing()
+        {
+            var dir = MovieDir("Ben-Hur");
+            var theirs = WriteFile(dir, "Ben-Hur.strm", ForeignUrl);
+
+            bool folderRemoved;
+            var deleted = StrmOwnership.DeleteOwnedFiles(dir, "http://fake-xtream", null, out folderRemoved);
+
+            Assert.Equal(0, deleted);
+            Assert.True(File.Exists(theirs));
+        }
+
+        [Fact]
+        public void DeleteOwnedFiles_AllOwned_PrunesFolder()
+        {
+            var dir = MovieDir("Ours");
+            WriteFile(dir, "Ours.strm", OwnedMovieUrl);
+            WriteFile(dir, "Ours.nfo", "<movie />");
+
+            bool folderRemoved;
+            var deleted = StrmOwnership.DeleteOwnedFiles(dir, "http://fake-xtream", null, out folderRemoved);
+
+            Assert.Equal(2, deleted);
+            Assert.True(folderRemoved);
+            Assert.False(Directory.Exists(dir));
+        }
+
+        [Fact]
+        public void DeleteOwnedFiles_ShowNfoGoesWithOwnedEpisodes()
+        {
+            var showDir = Path.Combine(TempDir.Path, "Shows", "Our Show");
+            var showNfo = WriteFile(showDir, "tvshow.nfo", "<tvshow />");
+            var episode = WriteFile(Path.Combine(showDir, "Season 01"), "S01E01.strm",
+                "http://fake-xtream/series/user/pass/5.mp4");
+
+            bool folderRemoved;
+            var deleted = StrmOwnership.DeleteOwnedFiles(showDir, "http://fake-xtream", null, out folderRemoved);
+
+            Assert.Equal(2, deleted);
+            Assert.False(File.Exists(showNfo));
+            Assert.False(File.Exists(episode));
+            Assert.True(folderRemoved);
+        }
+
+        // -----------------------------------------------------------------
+        // Integration: orphan cleanup
+        // -----------------------------------------------------------------
+
+        [Fact]
+        public async Task OrphanCleanup_LeavesUserOwnedStrm()
+        {
+            var config = DefaultConfig();
+            config.CleanupOrphans = true;
+
+            // A STRM the user maintains themselves, pointing at their own NAS. The provider has
+            // never heard of it, so by path-difference alone it looks exactly like an orphan.
+            var userStrm = WriteFile(MovieDir("My Home Video"), "My Home Video.strm", ForeignUrl);
+
+            Handler.RespondWith("get_vod_streams",
+                VodStreamsJson(VodStream(streamId: 1, name: "Provider Movie", added: 1000)));
+
+            await MakeService().SyncMoviesAsync(config, None, SaveConfig);
+
+            Assert.True(File.Exists(userStrm),
+                "A STRM this plugin did not write must never be deleted as an orphan");
+        }
+
+        [Fact]
+        public async Task OrphanCleanup_StillRemovesOurOwnStaleFile()
+        {
+            var config = DefaultConfig();
+            config.CleanupOrphans = true;
+
+            var ourStale = WriteFile(MovieDir("Old Movie"), "Old Movie.strm", OwnedMovieUrl);
+
+            Handler.RespondWith("get_vod_streams",
+                VodStreamsJson(VodStream(streamId: 1, name: "New Movie", added: 1000)));
+
+            await MakeService().SyncMoviesAsync(config, None, SaveConfig);
+
+            Assert.False(File.Exists(ourStale),
+                "A stale file this plugin did write is still a real orphan");
+        }
+
+        // -----------------------------------------------------------------
+        // Integration: per-item exclusion
+        // -----------------------------------------------------------------
+
+        [Fact]
+        public async Task ExcludedMovie_LeavesUserFilesInSameFolder()
+        {
+            var config = DefaultConfig();
+            config.CleanupOrphans = false;
+            config.ExcludedVodStreamIds = new[] { 7 };
+
+            // Our output plus files the user added alongside it.
+            var dir = MovieDir("Drop Me");
+            var ourStrm = WriteFile(dir, "Drop Me.strm", OwnedMovieUrl);
+            var userTrailer = WriteFile(dir, "trailer.strm", ForeignUrl);
+            var userNfo = WriteFile(dir, "my-notes.nfo", "hand written");
+
+            Handler.RespondWith("get_vod_streams",
+                VodStreamsJson(VodStream(streamId: 7, name: "Drop Me", added: 1000)));
+
+            await MakeService().SyncMoviesAsync(config, None, SaveConfig);
+
+            Assert.False(File.Exists(ourStrm), "The excluded title's own STRM should go");
+            Assert.True(File.Exists(userTrailer), "A user's trailer.strm in the same folder must survive");
+            Assert.True(File.Exists(userNfo), "A user's hand-written NFO must survive");
+        }
+
+        [Fact]
+        public async Task ExcludedMovie_UserFolderWithSameTitleUntouched()
+        {
+            var config = DefaultConfig();
+            config.CleanupOrphans = false;
+            config.ExcludedVodStreamIds = new[] { 7 };
+
+            // The user's own copy, which merely shares a title with the provider's.
+            var userStrm = WriteFile(MovieDir("Ben-Hur"), "Ben-Hur.strm", ForeignUrl);
+
+            Handler.RespondWith("get_vod_streams",
+                VodStreamsJson(VodStream(streamId: 7, name: "Ben-Hur", added: 1000)));
+
+            await MakeService().SyncMoviesAsync(config, None, SaveConfig);
+
+            Assert.True(File.Exists(userStrm),
+                "Matching is by title, so a title match is not proof of ownership");
+        }
+    }
+}

--- a/Emby.Xtream.Plugin.Tests/SyncMoviesIntegrationTests.cs
+++ b/Emby.Xtream.Plugin.Tests/SyncMoviesIntegrationTests.cs
@@ -145,7 +145,7 @@ namespace Emby.Xtream.Plugin.Tests
             // Pre-write an orphan for "Old Movie"
             var orphanPath = MovieStrmPath("Old Movie");
             Directory.CreateDirectory(Path.GetDirectoryName(orphanPath));
-            File.WriteAllText(orphanPath, "orphan");
+            File.WriteAllText(orphanPath, "http://fake-xtream/movie/user/pass/99.mkv");
 
             // Provider returns a different movie only
             var json = VodStreamsJson(VodStream(streamId: 2, name: "New Movie", added: 1000));
@@ -179,7 +179,7 @@ namespace Emby.Xtream.Plugin.Tests
                 var name = $"Movie {i:D2}";
                 var dir = Path.Combine(moviesRoot, name);
                 Directory.CreateDirectory(dir);
-                File.WriteAllText(Path.Combine(dir, name + ".strm"), $"stream {i}");
+                File.WriteAllText(Path.Combine(dir, name + ".strm"), $"http://fake-xtream/movie/user/pass/{i}.mkv");
             }
 
             // Provider returns only movie 1 → 11 orphans out of 12 = 91.7%
@@ -213,7 +213,7 @@ namespace Emby.Xtream.Plugin.Tests
                 var name = $"Movie {i:D2}";
                 var dir = Path.Combine(moviesRoot, name);
                 Directory.CreateDirectory(dir);
-                File.WriteAllText(Path.Combine(dir, name + ".strm"), $"stream {i}");
+                File.WriteAllText(Path.Combine(dir, name + ".strm"), $"http://fake-xtream/movie/user/pass/{i}.mkv");
             }
 
             // Provider returns movies 1–10 → movies 11 and 12 become orphans
@@ -389,7 +389,7 @@ namespace Emby.Xtream.Plugin.Tests
 
             var staleDir = Path.Combine(TempDir.Path, "Movies", "Drop Me [tmdbid=550]");
             Directory.CreateDirectory(staleDir);
-            File.WriteAllText(Path.Combine(staleDir, "Drop Me [tmdbid=550].strm"), "http://old");
+            File.WriteAllText(Path.Combine(staleDir, "Drop Me [tmdbid=550].strm"), "http://fake-xtream/movie/user/pass/7.mkv");
 
             RegisterVodStreams(VodStreamsJson(
                 VodStream(streamId: 2, name: "Drop Me", added: 1000)));

--- a/Emby.Xtream.Plugin.Tests/SyncSeriesIntegrationTests.cs
+++ b/Emby.Xtream.Plugin.Tests/SyncSeriesIntegrationTests.cs
@@ -178,7 +178,7 @@ namespace Emby.Xtream.Plugin.Tests
             // Pre-write an orphan episode for "Old Show"
             var orphanStrm = EpisodeStrmPath("Old Show", season: 1, episode: 1, title: "Gone");
             Directory.CreateDirectory(Path.GetDirectoryName(orphanStrm));
-            File.WriteAllText(orphanStrm, "orphan");
+            File.WriteAllText(orphanStrm, "http://fake-xtream/series/user/pass/99.mp4");
 
             // Provider returns only "New Show"
             var list = SeriesListJson(Series(seriesId: 2, name: "New Show", lastModified: "3000"));
@@ -511,7 +511,7 @@ namespace Emby.Xtream.Plugin.Tests
 
             var staleSeasonDir = Path.Combine(TempDir.Path, "Shows", "Drop Show", "Season 01");
             Directory.CreateDirectory(staleSeasonDir);
-            File.WriteAllText(Path.Combine(staleSeasonDir, "Drop Show - S01E01.strm"), "http://old");
+            File.WriteAllText(Path.Combine(staleSeasonDir, "Drop Show - S01E01.strm"), "http://fake-xtream/series/user/pass/7.mp4");
 
             Handler.RespondWith("action=get_series", SeriesListJson(
                 Series(seriesId: 2, name: "Drop Show", lastModified: "1000")));

--- a/Emby.Xtream.Plugin/Api/XtreamTunerApi.cs
+++ b/Emby.Xtream.Plugin/Api/XtreamTunerApi.cs
@@ -528,10 +528,20 @@ namespace Emby.Xtream.Plugin.Api
 
             try
             {
-                await syncService.SyncMoviesAsync(
+                var ran = await syncService.SyncMoviesAsync(
                     config,
                     CancellationToken.None,
                     () => Plugin.Instance.SaveConfiguration()).ConfigureAwait(false);
+
+                // The IsRunning check above is a fast path; the service holds the real gate and is
+                // the only thing that can answer this without a race.
+                if (!ran)
+                {
+                    result.Success = false;
+                    result.Message = "Movie sync is already running.";
+                    return result;
+                }
+
                 var progress = syncService.MovieProgress;
                 if (!string.IsNullOrEmpty(progress.AbortReason))
                 {
@@ -583,10 +593,19 @@ namespace Emby.Xtream.Plugin.Api
 
             try
             {
-                await syncService.SyncSeriesAsync(
+                var ran = await syncService.SyncSeriesAsync(
                     config,
                     CancellationToken.None,
                     () => Plugin.Instance.SaveConfiguration()).ConfigureAwait(false);
+
+                // See Post(SyncMovies): the service gate is authoritative, the check above is not.
+                if (!ran)
+                {
+                    result.Success = false;
+                    result.Message = "Series sync is already running.";
+                    return result;
+                }
+
                 var progress = syncService.SeriesProgress;
                 if (!string.IsNullOrEmpty(progress.AbortReason))
                 {

--- a/Emby.Xtream.Plugin/Api/XtreamTunerApi.cs
+++ b/Emby.Xtream.Plugin/Api/XtreamTunerApi.cs
@@ -677,7 +677,13 @@ namespace Emby.Xtream.Plugin.Api
             if (syncService.FailedItems.Count == 0)
                 return new SyncResult { Success = false, Message = "No failed items to retry." };
 
-            await syncService.RetryFailedAsync(CancellationToken.None).ConfigureAwait(false);
+            var ran = await syncService.RetryFailedAsync(CancellationToken.None).ConfigureAwait(false);
+
+            // The IsRunning check above is a fast path; the service holds the real gate. Without
+            // this the endpoint reports "Retry complete" for a retry that never started.
+            if (!ran)
+                return new SyncResult { Success = false, Message = "A sync is already running." };
+
             var p = syncService.MovieProgress;
             return new SyncResult
             {

--- a/Emby.Xtream.Plugin/Api/XtreamTunerApi.cs
+++ b/Emby.Xtream.Plugin/Api/XtreamTunerApi.cs
@@ -1427,8 +1427,11 @@ namespace Emby.Xtream.Plugin.Api
             var sanitized = new StringBuilder();
             foreach (var line in lines)
             {
+                // Raw values, not escaped: SanitizeLine redacts both forms itself. Passing the
+                // escaped form here would leave the raw credentials unredacted in the log a user
+                // is about to attach to a bug report.
                 var s = LogSanitizer.SanitizeLine(line,
-                    Uri.EscapeDataString(config.Username ?? string.Empty), Uri.EscapeDataString(config.Password ?? string.Empty),
+                    config.Username, config.Password,
                     config.DispatcharrUser, config.DispatcharrPass);
                 sanitized.AppendLine(s);
             }

--- a/Emby.Xtream.Plugin/Api/XtreamTunerApi.cs
+++ b/Emby.Xtream.Plugin/Api/XtreamTunerApi.cs
@@ -677,22 +677,32 @@ namespace Emby.Xtream.Plugin.Api
             if (syncService.FailedItems.Count == 0)
                 return new SyncResult { Success = false, Message = "No failed items to retry." };
 
-            var ran = await syncService.RetryFailedAsync(CancellationToken.None).ConfigureAwait(false);
-
-            // The IsRunning check above is a fast path; the service holds the real gate. Without
-            // this the endpoint reports "Retry complete" for a retry that never started.
-            if (!ran)
-                return new SyncResult { Success = false, Message = "A sync is already running." };
-
-            var p = syncService.MovieProgress;
-            return new SyncResult
+            // Catch like the sibling sync endpoints do. RetryFailedAsync can throw (reading the
+            // configuration needs ApplicationPaths), and an uncaught exception here comes back as
+            // a generic ServiceStack error DTO instead of the SyncResult the UI expects.
+            try
             {
-                Success = true,
-                Message = "Retry complete.",
-                Total = p.Total,
-                Completed = p.Completed,
-                Failed = p.Failed
-            };
+                var ran = await syncService.RetryFailedAsync(CancellationToken.None).ConfigureAwait(false);
+
+                // The IsRunning check above is a fast path; the service holds the real gate.
+                // Without this the endpoint reports "Retry complete" for a retry that never started.
+                if (!ran)
+                    return new SyncResult { Success = false, Message = "A sync is already running." };
+
+                var p = syncService.MovieProgress;
+                return new SyncResult
+                {
+                    Success = true,
+                    Message = "Retry complete.",
+                    Total = p.Total,
+                    Completed = p.Completed,
+                    Failed = p.Failed
+                };
+            }
+            catch (Exception ex)
+            {
+                return new SyncResult { Success = false, Message = "Retry failed: " + ex.Message };
+            }
         }
 
         public object Get(GetDashboard request)

--- a/Emby.Xtream.Plugin/Api/XtreamTunerApi.cs
+++ b/Emby.Xtream.Plugin/Api/XtreamTunerApi.cs
@@ -817,9 +817,8 @@ namespace Emby.Xtream.Plugin.Api
 
                 foreach (var dir in dirs)
                 {
-                    bool folderRemoved;
-                    var deleted = Emby.Xtream.Plugin.Service.StrmOwnership.DeleteOwnedFiles(
-                        dir, config.BaseUrl, config.DispatcharrUrl, out folderRemoved);
+                    var deleted = StrmOwnership.DeleteOwnedFiles(
+                        dir, config.BaseUrl, config.DispatcharrUrl, out var folderRemoved);
 
                     removedFiles += deleted;
                     if (folderRemoved)

--- a/Emby.Xtream.Plugin/Api/XtreamTunerApi.cs
+++ b/Emby.Xtream.Plugin/Api/XtreamTunerApi.cs
@@ -787,14 +787,39 @@ namespace Emby.Xtream.Plugin.Api
                     return result;
                 }
 
+                // Clear only what this plugin wrote. The library root can be shared with content
+                // the user manages themselves, and a recursive delete of the whole root took that
+                // with it — the same class of data loss as BUG-028, reached through a button
+                // instead of a sync. See ADR-014.
                 var dirs = Directory.GetDirectories(root, "*", SearchOption.TopDirectoryOnly);
-                result.DeletedFolders = dirs.Length;
+                var removedFolders = 0;
+                var removedFiles = 0;
+                var keptFolders = 0;
 
-                Directory.Delete(root, true);
-                Directory.CreateDirectory(root);
+                foreach (var dir in dirs)
+                {
+                    bool folderRemoved;
+                    var deleted = Emby.Xtream.Plugin.Service.StrmOwnership.DeleteOwnedFiles(
+                        dir, config.BaseUrl, config.DispatcharrUrl, out folderRemoved);
 
+                    removedFiles += deleted;
+                    if (folderRemoved)
+                    {
+                        removedFolders++;
+                    }
+                    else
+                    {
+                        keptFolders++;
+                    }
+                }
+
+                result.DeletedFolders = removedFolders;
                 result.Success = true;
-                result.Message = string.Format("Deleted {0} folders from {1}.", dirs.Length, folderName);
+                result.Message = keptFolders > 0
+                    ? string.Format(
+                        "Deleted {0} folders ({1} files) from {2}. Kept {3} folder(s) holding content this plugin did not write.",
+                        removedFolders, removedFiles, folderName, keptFolders)
+                    : string.Format("Deleted {0} folders ({1} files) from {2}.", removedFolders, removedFiles, folderName);
             }
             catch (Exception ex)
             {

--- a/Emby.Xtream.Plugin/Api/XtreamTunerApi.cs
+++ b/Emby.Xtream.Plugin/Api/XtreamTunerApi.cs
@@ -1428,7 +1428,7 @@ namespace Emby.Xtream.Plugin.Api
             foreach (var line in lines)
             {
                 var s = LogSanitizer.SanitizeLine(line,
-                    config.Username, config.Password,
+                    Uri.EscapeDataString(config.Username ?? string.Empty), Uri.EscapeDataString(config.Password ?? string.Empty),
                     config.DispatcharrUser, config.DispatcharrPass);
                 sanitized.AppendLine(s);
             }

--- a/Emby.Xtream.Plugin/Service/CatalogueFetchResult.cs
+++ b/Emby.Xtream.Plugin/Service/CatalogueFetchResult.cs
@@ -1,0 +1,35 @@
+using System.Collections.Generic;
+
+namespace Emby.Xtream.Plugin.Service
+{
+    /// <summary>
+    /// The outcome of fetching a catalogue (VOD streams or series) from the provider,
+    /// carrying whether every requested category actually answered.
+    /// </summary>
+    /// <remarks>
+    /// A per-category request that fails used to be swallowed into an empty list, which is
+    /// indistinguishable from a category that is genuinely empty. That empty result then flowed
+    /// into the valid-path set and orphan cleanup deleted the category's existing files. A single
+    /// provider 502 across many categories usually lands under <see
+    /// cref="PluginConfiguration.OrphanSafetyThreshold"/>, so the ratio guard did not catch it.
+    ///
+    /// <see cref="HadFailures"/> gates cleanup only. The delta watermark is still computed over
+    /// <see cref="Items"/> — the titles that did come back — because freezing it entirely would
+    /// make every later sync re-process the categories that succeeded.
+    /// </remarks>
+    /// <typeparam name="T">The catalogue item type (<c>VodStreamInfo</c> or <c>SeriesInfo</c>).</typeparam>
+    internal sealed class CatalogueFetchResult<T>
+    {
+        /// <summary>Items returned by the categories that answered successfully.</summary>
+        public List<T> Items { get; set; } = new List<T>();
+
+        /// <summary>True when at least one requested category failed to answer.</summary>
+        public bool HadFailures { get { return FailedCategoryCount > 0; } }
+
+        /// <summary>How many requested categories failed.</summary>
+        public int FailedCategoryCount { get; set; }
+
+        /// <summary>How many categories were requested (0 for a whole-catalogue fetch).</summary>
+        public int RequestedCategoryCount { get; set; }
+    }
+}

--- a/Emby.Xtream.Plugin/Service/CatalogueFetchResult.cs
+++ b/Emby.Xtream.Plugin/Service/CatalogueFetchResult.cs
@@ -24,7 +24,7 @@ namespace Emby.Xtream.Plugin.Service
         public List<T> Items { get; set; } = new List<T>();
 
         /// <summary>True when at least one requested category failed to answer.</summary>
-        public bool HadFailures { get { return FailedCategoryCount > 0; } }
+        public bool HadFailures => FailedCategoryCount > 0;
 
         /// <summary>How many requested categories failed.</summary>
         public int FailedCategoryCount { get; set; }

--- a/Emby.Xtream.Plugin/Service/LiveTvService.cs
+++ b/Emby.Xtream.Plugin/Service/LiveTvService.cs
@@ -349,7 +349,7 @@ namespace Emby.Xtream.Plugin.Service
             var extension = string.Equals(config.LiveTvOutputFormat, "ts", StringComparison.OrdinalIgnoreCase) ? "ts" : "m3u8";
             return string.Format(CultureInfo.InvariantCulture,
                 "{0}/live/{1}/{2}/{3}.{4}",
-                config.BaseUrl, config.Username, config.Password, channel.StreamId, extension);
+                config.BaseUrl, Uri.EscapeDataString(config.Username ?? string.Empty), Uri.EscapeDataString(config.Password ?? string.Empty), channel.StreamId, extension);
         }
 
         private async Task<string> GenerateXmltvAsync(List<LiveStreamInfo> channels, PluginConfiguration config, CancellationToken cancellationToken)
@@ -600,7 +600,7 @@ namespace Emby.Xtream.Plugin.Service
                     url = string.Format(
                         CultureInfo.InvariantCulture,
                         "{0}/xmltv.php?username={1}&password={2}",
-                        config.BaseUrl, config.Username, config.Password);
+                        config.BaseUrl, Uri.EscapeDataString(config.Username ?? string.Empty), Uri.EscapeDataString(config.Password ?? string.Empty));
                     _logger.Info("Fetching bulk XMLTV EPG from {0}/xmltv.php", config.BaseUrl);
                 }
 
@@ -660,7 +660,7 @@ namespace Emby.Xtream.Plugin.Service
             var url = string.Format(
                 CultureInfo.InvariantCulture,
                 "{0}/player_api.php?username={1}&password={2}&action=get_simple_data_table&stream_id={3}",
-                config.BaseUrl, config.Username, config.Password, streamId);
+                config.BaseUrl, Uri.EscapeDataString(config.Username ?? string.Empty), Uri.EscapeDataString(config.Password ?? string.Empty), streamId);
 
             using (var httpClient = Plugin.CreateHttpClient())
             {

--- a/Emby.Xtream.Plugin/Service/LogSanitizer.cs
+++ b/Emby.Xtream.Plugin/Service/LogSanitizer.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Text.RegularExpressions;
 
 namespace Emby.Xtream.Plugin.Service
@@ -36,15 +37,13 @@ namespace Emby.Xtream.Plugin.Service
 
             var s = line;
 
-            // Redact specific config values if non-empty
-            if (!string.IsNullOrEmpty(username))
-                s = s.Replace(username, "<redacted>");
-            if (!string.IsNullOrEmpty(password))
-                s = s.Replace(password, "<redacted>");
-            if (!string.IsNullOrEmpty(dispatcharrUser))
-                s = s.Replace(dispatcharrUser, "<redacted>");
-            if (!string.IsNullOrEmpty(dispatcharrPass))
-                s = s.Replace(dispatcharrPass, "<redacted>");
+            // Redact specific config values if non-empty. Callers pass the raw values; both the
+            // raw and percent-encoded forms are redacted here, because generated URLs carry the
+            // escaped form while other log lines carry the raw one.
+            s = RedactValue(s, username);
+            s = RedactValue(s, password);
+            s = RedactValue(s, dispatcharrUser);
+            s = RedactValue(s, dispatcharrPass);
 
             // Redact IP addresses, but preserve version numbers (e.g. Version=1.2.0.0)
             // Replace version patterns with placeholders first, then redact IPs, then restore
@@ -68,6 +67,42 @@ namespace Emby.Xtream.Plugin.Service
 
             // Redact hostnames in stream URLs
             s = ProviderHostRegex.Replace(s, "$1<provider-host>$3$4");
+
+            return s;
+        }
+
+        /// <summary>
+        /// Redacts <paramref name="value"/> from <paramref name="line"/> in both its raw and
+        /// percent-encoded forms.
+        /// </summary>
+        /// <remarks>
+        /// Credentials go into generated URLs escaped, so a password of <c>p/w</c> appears in a
+        /// stream URL as <c>p%2Fw</c>. Redacting only one form leaks the other into the log a user
+        /// attaches to a bug report.
+        /// </remarks>
+        private static string RedactValue(string line, string value)
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                return line;
+            }
+
+            var s = line.Replace(value, "<redacted>");
+
+            string escaped;
+            try
+            {
+                escaped = Uri.EscapeDataString(value);
+            }
+            catch (UriFormatException)
+            {
+                return s;
+            }
+
+            if (!string.Equals(escaped, value, StringComparison.Ordinal))
+            {
+                s = s.Replace(escaped, "<redacted>");
+            }
 
             return s;
         }

--- a/Emby.Xtream.Plugin/Service/LogSanitizer.cs
+++ b/Emby.Xtream.Plugin/Service/LogSanitizer.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Text.RegularExpressions;
 
 namespace Emby.Xtream.Plugin.Service
@@ -40,10 +41,19 @@ namespace Emby.Xtream.Plugin.Service
             // Redact specific config values if non-empty. Callers pass the raw values; both the
             // raw and percent-encoded forms are redacted here, because generated URLs carry the
             // escaped form while other log lines carry the raw one.
-            s = RedactValue(s, username);
-            s = RedactValue(s, password);
-            s = RedactValue(s, dispatcharrUser);
-            s = RedactValue(s, dispatcharrPass);
+            //
+            // Longest first. A shorter value that is a prefix of a longer one would otherwise
+            // rewrite it out of existence before its own turn: username "abc" against password
+            // "abc/secret" leaves "<redacted>/secret", and the "/secret" tail reaches the
+            // downloadable log.
+            var values = new[] { username, password, dispatcharrUser, dispatcharrPass }
+                .Where(v => !string.IsNullOrEmpty(v))
+                .OrderByDescending(v => v.Length);
+
+            foreach (var value in values)
+            {
+                s = RedactValue(s, value);
+            }
 
             // Redact IP addresses, but preserve version numbers (e.g. Version=1.2.0.0)
             // Replace version patterns with placeholders first, then redact IPs, then restore

--- a/Emby.Xtream.Plugin/Service/LogSanitizer.cs
+++ b/Emby.Xtream.Plugin/Service/LogSanitizer.cs
@@ -38,22 +38,7 @@ namespace Emby.Xtream.Plugin.Service
 
             var s = line;
 
-            // Redact specific config values if non-empty. Callers pass the raw values; both the
-            // raw and percent-encoded forms are redacted here, because generated URLs carry the
-            // escaped form while other log lines carry the raw one.
-            //
-            // Longest first. A shorter value that is a prefix of a longer one would otherwise
-            // rewrite it out of existence before its own turn: username "abc" against password
-            // "abc/secret" leaves "<redacted>/secret", and the "/secret" tail reaches the
-            // downloadable log.
-            var values = new[] { username, password, dispatcharrUser, dispatcharrPass }
-                .Where(v => !string.IsNullOrEmpty(v))
-                .OrderByDescending(v => v.Length);
-
-            foreach (var value in values)
-            {
-                s = RedactValue(s, value);
-            }
+            s = RedactCredentials(s, username, password, dispatcharrUser, dispatcharrPass);
 
             // Redact IP addresses, but preserve version numbers (e.g. Version=1.2.0.0)
             // Replace version patterns with placeholders first, then redact IPs, then restore
@@ -82,39 +67,52 @@ namespace Emby.Xtream.Plugin.Service
         }
 
         /// <summary>
-        /// Redacts <paramref name="value"/> from <paramref name="line"/> in both its raw and
-        /// percent-encoded forms.
+        /// Redacts every configured credential from <paramref name="line"/>, in both its raw and
+        /// percent-encoded form.
         /// </summary>
         /// <remarks>
         /// Credentials go into generated URLs escaped, so a password of <c>p/w</c> appears in a
         /// stream URL as <c>p%2Fw</c>. Redacting only one form leaks the other into the log a user
         /// attaches to a bug report.
+        ///
+        /// Every form of every credential goes into one alternation, longest first, applied in a
+        /// single pass. Replacing them one at a time is not safe no matter how the credentials are
+        /// ordered: a short value can land inside another value's escaped form and split it, which
+        /// both stops the longer one from matching and leaves readable pieces of it behind. A
+        /// single pass also cannot match inside text it has already replaced.
         /// </remarks>
-        private static string RedactValue(string line, string value)
+        private static string RedactCredentials(string line, params string[] values)
         {
-            if (string.IsNullOrEmpty(value))
+            var candidates = values
+                .Where(v => !string.IsNullOrEmpty(v))
+                .SelectMany(v => new[] { v, TryEscape(v) })
+                .Where(v => !string.IsNullOrEmpty(v))
+                .Distinct(StringComparer.Ordinal)
+                .OrderByDescending(v => v.Length)
+                .ToList();
+
+            if (candidates.Count == 0)
             {
                 return line;
             }
 
-            var s = line.Replace(value, "<redacted>");
+            // Alternation is leftmost-first, so listing longest first makes the longest candidate
+            // win at any position where several could match.
+            var pattern = string.Join("|", candidates.Select(Regex.Escape));
+            return Regex.Replace(line, pattern, "<redacted>");
+        }
 
-            string escaped;
+        private static string TryEscape(string value)
+        {
             try
             {
-                escaped = Uri.EscapeDataString(value);
+                return Uri.EscapeDataString(value);
             }
             catch (UriFormatException)
             {
-                return s;
+                // Nothing to add for a value the escaper rejects; the raw form is still covered.
+                return null;
             }
-
-            if (!string.Equals(escaped, value, StringComparison.Ordinal))
-            {
-                s = s.Replace(escaped, "<redacted>");
-            }
-
-            return s;
         }
     }
 }

--- a/Emby.Xtream.Plugin/Service/StrmOwnership.cs
+++ b/Emby.Xtream.Plugin/Service/StrmOwnership.cs
@@ -1,0 +1,197 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Emby.Xtream.Plugin.Service
+{
+    /// <summary>
+    /// Decides whether a file in the STRM library was written by this plugin.
+    /// </summary>
+    /// <remarks>
+    /// Every delete path here matches by title or by "is a .strm", neither of which proves the
+    /// plugin wrote the file. A user's own <c>Ben-Hur</c> folder, a hand-written <c>.nfo</c>, or a
+    /// <c>trailer.strm</c> sitting beside plugin output all looked deletable.
+    ///
+    /// No manifest is needed to fix that: the plugin's own output already identifies itself. Every
+    /// STRM it writes contains the provider URL it was built from
+    /// (<c>{BaseUrl}/movie|series/{user}/{pass}/{id}.{ext}</c>), or a Dispatcharr proxy URL for
+    /// multi-version entries. A STRM whose content starts with one of the configured hosts is ours.
+    /// This needs no new state, no migration, and works on libraries that already exist.
+    ///
+    /// Everything here fails safe: anything not provably ours is treated as foreign and kept. The
+    /// cost of a false negative is an orphan that survives; the cost of a false positive is
+    /// destroyed user data.
+    ///
+    /// If <c>BaseUrl</c> changes, previously-written STRMs stop reading as owned and simply stop
+    /// being cleaned. That is the safe direction, and ADR-004's naming-version resync already covers
+    /// rewriting them.
+    /// </remarks>
+    internal static class StrmOwnership
+    {
+        /// <summary>The show-level NFO the plugin writes at a series root.</summary>
+        private const string ShowNfoName = "tvshow.nfo";
+
+        /// <summary>
+        /// True when the STRM at <paramref name="path"/> was written by this plugin.
+        /// </summary>
+        /// <param name="path">Full path to a <c>.strm</c> file.</param>
+        /// <param name="baseUrl">Configured Xtream server URL.</param>
+        /// <param name="dispatcharrUrl">Configured Dispatcharr URL, if any.</param>
+        public static bool IsOwnedStrm(string path, string baseUrl, string dispatcharrUrl)
+        {
+            try
+            {
+                var content = File.ReadAllText(path).Trim();
+                if (content.Length == 0)
+                {
+                    return false;
+                }
+
+                return StartsWithHost(content, baseUrl) || StartsWithHost(content, dispatcharrUrl);
+            }
+            catch (Exception)
+            {
+                // Unreadable means not provably ours, so leave it alone.
+                return false;
+            }
+        }
+
+        private static bool StartsWithHost(string content, string url)
+        {
+            if (string.IsNullOrWhiteSpace(url))
+            {
+                return false;
+            }
+
+            return content.StartsWith(url.TrimEnd('/'), StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// True when the NFO at <paramref name="nfoPath"/> was written by this plugin.
+        /// </summary>
+        /// <remarks>
+        /// The plugin writes exactly two NFO shapes: <c>{folderName}.nfo</c> beside the matching
+        /// <c>{folderName}.strm</c> (movies), and <c>tvshow.nfo</c> at a series root. Anything else
+        /// in the library — a user's <c>movie.nfo</c>, a hand-edited episode NFO — is foreign.
+        /// </remarks>
+        /// <param name="nfoPath">Full path to a <c>.nfo</c> file.</param>
+        /// <param name="ownedStrmsInTree">Owned STRM paths found anywhere under the item folder.</param>
+        public static bool IsOwnedNfo(string nfoPath, ICollection<string> ownedStrmsInTree)
+        {
+            if (ownedStrmsInTree == null || ownedStrmsInTree.Count == 0)
+            {
+                return false;
+            }
+
+            if (string.Equals(Path.GetFileName(nfoPath), ShowNfoName, StringComparison.OrdinalIgnoreCase))
+            {
+                // A tvshow.nfo only exists because we wrote episodes under it.
+                return true;
+            }
+
+            var dir = Path.GetDirectoryName(nfoPath);
+            var baseName = Path.GetFileNameWithoutExtension(nfoPath);
+
+            return ownedStrmsInTree.Any(strm =>
+                string.Equals(Path.GetDirectoryName(strm), dir, StringComparison.OrdinalIgnoreCase) &&
+                string.Equals(Path.GetFileNameWithoutExtension(strm), baseName, StringComparison.OrdinalIgnoreCase));
+        }
+
+        /// <summary>
+        /// Deletes every plugin-written <c>.strm</c> and <c>.nfo</c> under <paramref name="dir"/>,
+        /// then prunes whatever that emptied. Files the plugin did not write stay, and so does the
+        /// folder if it still holds any of them.
+        /// </summary>
+        /// <param name="dir">Item folder to clear.</param>
+        /// <param name="baseUrl">Configured Xtream server URL.</param>
+        /// <param name="dispatcharrUrl">Configured Dispatcharr URL, if any.</param>
+        /// <param name="folderRemoved">True when <paramref name="dir"/> itself was pruned away.</param>
+        /// <returns>Number of files deleted.</returns>
+        public static int DeleteOwnedFiles(string dir, string baseUrl, string dispatcharrUrl, out bool folderRemoved)
+        {
+            folderRemoved = false;
+
+            if (!Directory.Exists(dir))
+            {
+                folderRemoved = true;
+                return 0;
+            }
+
+            // Resolve ownership across the whole tree BEFORE deleting anything, because the NFO
+            // rule is defined in terms of the STRM files that were there.
+            var ownedStrms = Directory
+                .GetFiles(dir, "*.strm", SearchOption.AllDirectories)
+                .Where(f => IsOwnedStrm(f, baseUrl, dispatcharrUrl))
+                .ToList();
+
+            if (ownedStrms.Count == 0)
+            {
+                // Nothing here is ours. Matching is by title alone, so this is the case where a
+                // user's own folder happens to share a name with a provider title.
+                return 0;
+            }
+
+            var deleted = 0;
+
+            foreach (var strm in ownedStrms)
+            {
+                if (TryDelete(strm))
+                {
+                    deleted++;
+                }
+            }
+
+            foreach (var nfo in Directory.GetFiles(dir, "*.nfo", SearchOption.AllDirectories))
+            {
+                if (IsOwnedNfo(nfo, ownedStrms) && TryDelete(nfo))
+                {
+                    deleted++;
+                }
+            }
+
+            folderRemoved = TryPruneEmptyTree(dir);
+            return deleted;
+        }
+
+        private static bool TryDelete(string path)
+        {
+            try
+            {
+                File.Delete(path);
+                return true;
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Deletes <paramref name="dir"/> and any subdirectory of it that is empty, deepest first.
+        /// Stops at the first level that still holds something.
+        /// </summary>
+        /// <param name="dir">The directory to prune.</param>
+        /// <returns>True if <paramref name="dir"/> itself was removed.</returns>
+        public static bool TryPruneEmptyTree(string dir)
+        {
+            if (!Directory.Exists(dir))
+            {
+                return true;
+            }
+
+            foreach (var sub in Directory.GetDirectories(dir))
+            {
+                TryPruneEmptyTree(sub);
+            }
+
+            if (Directory.GetFileSystemEntries(dir).Length == 0)
+            {
+                Directory.Delete(dir);
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/Emby.Xtream.Plugin/Service/StrmOwnership.cs
+++ b/Emby.Xtream.Plugin/Service/StrmOwnership.cs
@@ -64,7 +64,16 @@ namespace Emby.Xtream.Plugin.Service
                 return false;
             }
 
-            return content.StartsWith(url.TrimEnd('/'), StringComparison.OrdinalIgnoreCase);
+            var prefix = url.TrimEnd('/');
+            if (!content.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            // Require a path boundary. A bare prefix match means a configured BaseUrl of
+            // http://nas also claims a user's http://nas-backup/media/Movie.mkv, and this class
+            // deletes what it claims.
+            return content.Length == prefix.Length || content[prefix.Length] == '/';
         }
 
         /// <summary>
@@ -180,15 +189,25 @@ namespace Emby.Xtream.Plugin.Service
                 return true;
             }
 
-            foreach (var sub in Directory.GetDirectories(dir))
+            try
             {
-                TryPruneEmptyTree(sub);
-            }
+                foreach (var sub in Directory.GetDirectories(dir))
+                {
+                    TryPruneEmptyTree(sub);
+                }
 
-            if (Directory.GetFileSystemEntries(dir).Length == 0)
+                if (Directory.GetFileSystemEntries(dir).Length == 0)
+                {
+                    Directory.Delete(dir);
+                    return true;
+                }
+            }
+            catch (Exception)
             {
-                Directory.Delete(dir);
-                return true;
+                // A file can appear between the emptiness check and the delete, or permissions can
+                // block it. The Try prefix promises this does not throw, and the delete-all endpoint
+                // wraps its whole folder loop in one try/catch — letting this escape would abort the
+                // remaining folders and report the entire operation as failed.
             }
 
             return false;

--- a/Emby.Xtream.Plugin/Service/StrmOwnership.cs
+++ b/Emby.Xtream.Plugin/Service/StrmOwnership.cs
@@ -127,12 +127,26 @@ namespace Emby.Xtream.Plugin.Service
                 return 0;
             }
 
-            // Resolve ownership across the whole tree BEFORE deleting anything, because the NFO
-            // rule is defined in terms of the STRM files that were there.
-            var ownedStrms = Directory
-                .GetFiles(dir, "*.strm", SearchOption.AllDirectories)
-                .Where(f => IsOwnedStrm(f, baseUrl, dispatcharrUrl))
-                .ToList();
+            List<string> ownedStrms;
+            List<string> nfos;
+            try
+            {
+                // Resolve ownership across the whole tree BEFORE deleting anything, because the
+                // NFO rule is defined in terms of the STRM files that were there.
+                ownedStrms = Directory
+                    .GetFiles(dir, "*.strm", SearchOption.AllDirectories)
+                    .Where(f => IsOwnedStrm(f, baseUrl, dispatcharrUrl))
+                    .ToList();
+                nfos = Directory.GetFiles(dir, "*.nfo", SearchOption.AllDirectories).ToList();
+            }
+            catch (Exception)
+            {
+                // An access error or a filesystem race must not escape. The delete-all endpoint
+                // wraps its whole folder loop in one try/catch, so letting this out would stop
+                // cleanup for every remaining folder. Retaining this one folder is the safe
+                // outcome, and it is reported as kept rather than removed.
+                return 0;
+            }
 
             if (ownedStrms.Count == 0)
             {
@@ -151,7 +165,7 @@ namespace Emby.Xtream.Plugin.Service
                 }
             }
 
-            foreach (var nfo in Directory.GetFiles(dir, "*.nfo", SearchOption.AllDirectories))
+            foreach (var nfo in nfos)
             {
                 if (IsOwnedNfo(nfo, ownedStrms) && TryDelete(nfo))
                 {

--- a/Emby.Xtream.Plugin/Service/StrmOwnership.cs
+++ b/Emby.Xtream.Plugin/Service/StrmOwnership.cs
@@ -86,7 +86,7 @@ namespace Emby.Xtream.Plugin.Service
         /// </remarks>
         /// <param name="nfoPath">Full path to a <c>.nfo</c> file.</param>
         /// <param name="ownedStrmsInTree">Owned STRM paths found anywhere under the item folder.</param>
-        public static bool IsOwnedNfo(string nfoPath, ICollection<string> ownedStrmsInTree)
+        private static bool IsOwnedNfo(string nfoPath, ICollection<string> ownedStrmsInTree)
         {
             if (ownedStrmsInTree == null || ownedStrmsInTree.Count == 0)
             {
@@ -182,7 +182,7 @@ namespace Emby.Xtream.Plugin.Service
         /// </summary>
         /// <param name="dir">The directory to prune.</param>
         /// <returns>True if <paramref name="dir"/> itself was removed.</returns>
-        public static bool TryPruneEmptyTree(string dir)
+        private static bool TryPruneEmptyTree(string dir)
         {
             if (!Directory.Exists(dir))
             {

--- a/Emby.Xtream.Plugin/Service/StrmSyncService.cs
+++ b/Emby.Xtream.Plugin/Service/StrmSyncService.cs
@@ -1370,11 +1370,15 @@ namespace Emby.Xtream.Plugin.Service
                 return false;
             }
 
-            var config = Plugin.Instance.Configuration;
-            _movieProgress = new SyncProgress { IsRunning = true, Phase = "Retrying failed items", Total = items.Count };
-
+            // Everything after the acquire must be inside the try. Plugin.Instance.Configuration
+            // can throw (ApplicationPaths may not be initialised yet), and a throw between the
+            // acquire and the try would hold the gate forever — every later movie sync would be
+            // refused until Emby restarts.
             try
             {
+                var config = Plugin.Instance.Configuration;
+                _movieProgress = new SyncProgress { IsRunning = true, Phase = "Retrying failed items", Total = items.Count };
+
                 var semaphore = new SemaphoreSlim(ResolveSyncParallelism(config));
                 var categoryNames = new Dictionary<int, string>();
                 var folderMappings = FolderMappingParser.Parse(config.MovieFolderMappings);

--- a/Emby.Xtream.Plugin/Service/StrmSyncService.cs
+++ b/Emby.Xtream.Plugin/Service/StrmSyncService.cs
@@ -135,6 +135,44 @@ namespace Emby.Xtream.Plugin.Service
         private readonly SemaphoreSlim _movieSyncGate = new SemaphoreSlim(1, 1);
         private readonly SemaphoreSlim _seriesSyncGate = new SemaphoreSlim(1, 1);
 
+        /// <summary>Lowest usable value for <see cref="PluginConfiguration.SyncParallelism"/>.</summary>
+        internal const int MinSyncParallelism = 1;
+
+        /// <summary>Highest usable value for <see cref="PluginConfiguration.SyncParallelism"/>.</summary>
+        internal const int MaxSyncParallelism = 10;
+
+        /// <summary>
+        /// Returns a usable parallelism, correcting a persisted value that is out of range.
+        /// </summary>
+        /// <remarks>
+        /// The config UI validates this, but the value is persisted to XML and survives hand edits
+        /// and migrations. Zero is the dangerous one: <c>new SemaphoreSlim(0)</c> has no permits, so
+        /// the first task waits forever and the sync hangs with no way out but editing the file.
+        /// </remarks>
+        internal static int GetSyncParallelism(PluginConfiguration config)
+        {
+            var configured = config.SyncParallelism;
+            if (configured >= MinSyncParallelism && configured <= MaxSyncParallelism)
+            {
+                return configured;
+            }
+
+            return configured < MinSyncParallelism ? MinSyncParallelism : MaxSyncParallelism;
+        }
+
+        private int ResolveSyncParallelism(PluginConfiguration config)
+        {
+            var resolved = GetSyncParallelism(config);
+            if (resolved != config.SyncParallelism)
+            {
+                _logger.Warn(
+                    "SyncParallelism is {0}, which is outside the usable range {1}-{2} — using {3} for this run",
+                    config.SyncParallelism, MinSyncParallelism, MaxSyncParallelism, resolved);
+            }
+
+            return resolved;
+        }
+
         private static void ReportTaskProgress(SyncProgress syncProgress, IProgress<double> taskProgress)
         {
             if (taskProgress == null) return;
@@ -430,7 +468,7 @@ namespace Emby.Xtream.Plugin.Service
                 _logger.Info("Starting movie STRM sync for {0} streams", allStreams.Count);
 
                 var writtenPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-                var semaphore = new SemaphoreSlim(config.SyncParallelism);
+                var semaphore = new SemaphoreSlim(ResolveSyncParallelism(config));
 
                 // Shared Dispatcharr VOD client — only queried per-movie, after smart-skip
                 Emby.Xtream.Plugin.Client.DispatcharrClient dispatcharrVodClient = null;
@@ -529,7 +567,7 @@ namespace Emby.Xtream.Plugin.Service
                         var streamUrl = string.Format(
                             CultureInfo.InvariantCulture,
                             "{0}/movie/{1}/{2}/{3}.{4}",
-                            config.BaseUrl, config.Username, config.Password, movie.StreamId, ext);
+                            config.BaseUrl, Uri.EscapeDataString(config.Username ?? string.Empty), Uri.EscapeDataString(config.Password ?? string.Empty), movie.StreamId, ext);
 
                         // Build list of STRM entries (multi-version via Dispatcharr, or single)
                         var strmEntries = new List<Tuple<string, string>>();
@@ -884,7 +922,7 @@ namespace Emby.Xtream.Plugin.Service
                 }
 
                 var writtenPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-                var semaphore = new SemaphoreSlim(config.SyncParallelism);
+                var semaphore = new SemaphoreSlim(ResolveSyncParallelism(config));
 
                 // Episode hash cache: load stored hashes so we can skip file I/O for unchanged series
                 var storedHashes = DeserializeEpisodeHashes(config.SeriesEpisodeHashesJson);
@@ -1155,7 +1193,7 @@ namespace Emby.Xtream.Plugin.Service
                                 var streamUrl = string.Format(
                                     CultureInfo.InvariantCulture,
                                     "{0}/series/{1}/{2}/{3}.{4}",
-                                    config.BaseUrl, config.Username, config.Password, episode.Id, ext);
+                                    config.BaseUrl, Uri.EscapeDataString(config.Username ?? string.Empty), Uri.EscapeDataString(config.Password ?? string.Empty), episode.Id, ext);
 
                                 // Skip write if file content is already up to date (avoids Emby library re-scan)
                                 var fileExists = File.Exists(strmPath);
@@ -1337,7 +1375,7 @@ namespace Emby.Xtream.Plugin.Service
 
             try
             {
-                var semaphore = new SemaphoreSlim(config.SyncParallelism);
+                var semaphore = new SemaphoreSlim(ResolveSyncParallelism(config));
                 var categoryNames = new Dictionary<int, string>();
                 var folderMappings = FolderMappingParser.Parse(config.MovieFolderMappings);
                 var writtenPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -1411,7 +1449,7 @@ namespace Emby.Xtream.Plugin.Service
             var streamUrl = string.Format(
                 CultureInfo.InvariantCulture,
                 "{0}/movie/{1}/{2}/{3}.{4}",
-                config.BaseUrl, config.Username, config.Password, item.StreamId, ext);
+                config.BaseUrl, Uri.EscapeDataString(config.Username ?? string.Empty), Uri.EscapeDataString(config.Password ?? string.Empty), item.StreamId, ext);
 
             var fileExists = File.Exists(strmPath);
 
@@ -1481,7 +1519,7 @@ namespace Emby.Xtream.Plugin.Service
                     var ext = !string.IsNullOrEmpty(ep.ContainerExtension) ? ep.ContainerExtension : "mp4";
                     var epUrl = string.Format(CultureInfo.InvariantCulture,
                         "{0}/series/{1}/{2}/{3}.{4}",
-                        config.BaseUrl, config.Username, config.Password, ep.Id, ext);
+                        config.BaseUrl, Uri.EscapeDataString(config.Username ?? string.Empty), Uri.EscapeDataString(config.Password ?? string.Empty), ep.Id, ext);
 
                     var fileExists = File.Exists(epPath);
 
@@ -1774,7 +1812,7 @@ namespace Emby.Xtream.Plugin.Service
             else
             {
                 result.RequestedCategoryCount = categoryIds.Length;
-                var semaphore = new SemaphoreSlim(config.SyncParallelism);
+                var semaphore = new SemaphoreSlim(ResolveSyncParallelism(config));
                 var tasks = categoryIds.Select(async catId =>
                 {
                     await semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
@@ -1855,7 +1893,7 @@ namespace Emby.Xtream.Plugin.Service
             else
             {
                 result.RequestedCategoryCount = categoryIds.Length;
-                var semaphore = new SemaphoreSlim(config.SyncParallelism);
+                var semaphore = new SemaphoreSlim(ResolveSyncParallelism(config));
                 var tasks = categoryIds.Select(async catId =>
                 {
                     await semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);

--- a/Emby.Xtream.Plugin/Service/StrmSyncService.cs
+++ b/Emby.Xtream.Plugin/Service/StrmSyncService.cs
@@ -1370,6 +1370,23 @@ namespace Emby.Xtream.Plugin.Service
                 return false;
             }
 
+            // A retry batch can contain series items, and those write episodes under Shows. Without
+            // the series gate a concurrent series sync would not have the retry-written paths in
+            // its valid set, so its orphan cleanup would delete them — and they would pass the
+            // ownership check precisely because the retry wrote them.
+            var needsSeriesGate = items.Any(i => i.ItemType == "Series");
+            var seriesGateHeld = false;
+            if (needsSeriesGate)
+            {
+                seriesGateHeld = await _seriesSyncGate.WaitAsync(0, cancellationToken).ConfigureAwait(false);
+                if (!seriesGateHeld)
+                {
+                    _movieSyncGate.Release();
+                    _logger.Warn("Retry requested while a series sync is already running — ignoring the duplicate request");
+                    return false;
+                }
+            }
+
             // Everything after the acquire must be inside the try. Plugin.Instance.Configuration
             // can throw (ApplicationPaths may not be initialised yet), and a throw between the
             // acquire and the try would hold the gate forever — every later movie sync would be
@@ -1425,6 +1442,10 @@ namespace Emby.Xtream.Plugin.Service
             {
                 _movieProgress.IsRunning = false;
                 _movieProgress.Phase = "Retry complete";
+                if (seriesGateHeld)
+                {
+                    _seriesSyncGate.Release();
+                }
                 _movieSyncGate.Release();
             }
         }

--- a/Emby.Xtream.Plugin/Service/StrmSyncService.cs
+++ b/Emby.Xtream.Plugin/Service/StrmSyncService.cs
@@ -127,6 +127,14 @@ namespace Emby.Xtream.Plugin.Service
         private SyncProgress _seriesProgress = new SyncProgress();
         private SyncProgress _episodeProgress = new SyncProgress();
 
+        // Single-flight gates. Each sync replaces its progress object wholesale and shares a
+        // written-path set, so two overlapping runs of the same kind corrupt each other's state.
+        // Movies and series are gated separately because they touch different roots and are
+        // deliberately runnable at the same time. RetryFailedAsync takes the movie gate: it writes
+        // movie files and reuses _movieProgress.
+        private readonly SemaphoreSlim _movieSyncGate = new SemaphoreSlim(1, 1);
+        private readonly SemaphoreSlim _seriesSyncGate = new SemaphoreSlim(1, 1);
+
         private static void ReportTaskProgress(SyncProgress syncProgress, IProgress<double> taskProgress)
         {
             if (taskProgress == null) return;
@@ -279,7 +287,39 @@ namespace Emby.Xtream.Plugin.Service
             return true;
         }
 
-        public async Task SyncMoviesAsync(PluginConfiguration config, CancellationToken cancellationToken, Action saveConfig = null, IProgress<double> taskProgress = null)
+        /// <summary>
+        /// Syncs movie STRM files. At most one movie sync runs at a time.
+        /// </summary>
+        /// <returns>
+        /// False when a movie sync was already in progress and this request was ignored.
+        /// True when this call ran (check <see cref="SyncProgress.AbortReason"/> for a run that
+        /// started and then bailed on configuration).
+        /// </returns>
+        public async Task<bool> SyncMoviesAsync(PluginConfiguration config, CancellationToken cancellationToken, Action saveConfig = null, IProgress<double> taskProgress = null)
+        {
+            // Single-flight gate, held for the whole operation. Callers check IsRunning first, but
+            // that is a fast path, not a lock: between the check and the assignment below, a second
+            // request or the scheduled task can pass it too. Two runs then share writtenPaths and
+            // the progress object, and whichever finishes first clears IsRunning while the other is
+            // still writing — admitting a third run mid-cleanup.
+            if (!await _movieSyncGate.WaitAsync(0, cancellationToken).ConfigureAwait(false))
+            {
+                _logger.Warn("Movie sync requested while one is already running — ignoring the duplicate request");
+                return false;
+            }
+
+            try
+            {
+                await SyncMoviesCoreAsync(config, cancellationToken, saveConfig, taskProgress).ConfigureAwait(false);
+                return true;
+            }
+            finally
+            {
+                _movieSyncGate.Release();
+            }
+        }
+
+        private async Task SyncMoviesCoreAsync(PluginConfiguration config, CancellationToken cancellationToken, Action saveConfig, IProgress<double> taskProgress)
         {
             ApplyUserAgentToSharedClient();
             CheckAndUpgradeNamingVersion(config, saveConfig);
@@ -679,7 +719,34 @@ namespace Emby.Xtream.Plugin.Service
             }
         }
 
-        public async Task SyncSeriesAsync(PluginConfiguration config, CancellationToken cancellationToken, Action saveConfig = null, IProgress<double> taskProgress = null)
+        /// <summary>
+        /// Syncs series STRM files. At most one series sync runs at a time.
+        /// </summary>
+        /// <returns>
+        /// False when a series sync was already in progress and this request was ignored.
+        /// True when this call ran.
+        /// </returns>
+        public async Task<bool> SyncSeriesAsync(PluginConfiguration config, CancellationToken cancellationToken, Action saveConfig = null, IProgress<double> taskProgress = null)
+        {
+            // See SyncMoviesAsync for why the caller's IsRunning check is not sufficient.
+            if (!await _seriesSyncGate.WaitAsync(0, cancellationToken).ConfigureAwait(false))
+            {
+                _logger.Warn("Series sync requested while one is already running — ignoring the duplicate request");
+                return false;
+            }
+
+            try
+            {
+                await SyncSeriesCoreAsync(config, cancellationToken, saveConfig, taskProgress).ConfigureAwait(false);
+                return true;
+            }
+            finally
+            {
+                _seriesSyncGate.Release();
+            }
+        }
+
+        private async Task SyncSeriesCoreAsync(PluginConfiguration config, CancellationToken cancellationToken, Action saveConfig, IProgress<double> taskProgress)
         {
             ApplyUserAgentToSharedClient();
             CheckAndUpgradeNamingVersion(config, saveConfig);
@@ -1247,11 +1314,23 @@ namespace Emby.Xtream.Plugin.Service
             }
         }
 
-        public async Task RetryFailedAsync(CancellationToken cancellationToken)
+        /// <summary>
+        /// Re-attempts the items that failed in the last sync.
+        /// </summary>
+        /// <returns>False when a movie sync or another retry was already running.</returns>
+        public async Task<bool> RetryFailedAsync(CancellationToken cancellationToken)
         {
             List<FailedSyncItem> items;
             lock (_failedItemsLock) { items = _failedItems.ToList(); }
-            if (items.Count == 0) return;
+            if (items.Count == 0) return true;
+
+            // Shares _movieProgress with SyncMoviesAsync and writes into the same movie tree, so it
+            // takes the same gate rather than racing a sync that is already underway.
+            if (!await _movieSyncGate.WaitAsync(0, cancellationToken).ConfigureAwait(false))
+            {
+                _logger.Warn("Retry requested while a movie sync is already running — ignoring the duplicate request");
+                return false;
+            }
 
             var config = Plugin.Instance.Configuration;
             _movieProgress = new SyncProgress { IsRunning = true, Phase = "Retrying failed items", Total = items.Count };
@@ -1297,11 +1376,14 @@ namespace Emby.Xtream.Plugin.Service
                     foreach (var s in succeeded)
                         _failedItems.Remove(s);
                 }
+
+                return true;
             }
             finally
             {
                 _movieProgress.IsRunning = false;
                 _movieProgress.Phase = "Retry complete";
+                _movieSyncGate.Release();
             }
         }
 

--- a/Emby.Xtream.Plugin/Service/StrmSyncService.cs
+++ b/Emby.Xtream.Plugin/Service/StrmSyncService.cs
@@ -1370,31 +1370,31 @@ namespace Emby.Xtream.Plugin.Service
                 return false;
             }
 
-            // A retry batch can contain series items, and those write episodes under Shows. Without
-            // the series gate a concurrent series sync would not have the retry-written paths in
-            // its valid set, so its orphan cleanup would delete them — and they would pass the
-            // ownership check precisely because the retry wrote them.
-            var needsSeriesGate = items.Any(i => i.ItemType == "Series");
+            // Nothing between acquiring a gate and its finally may throw, or the gate is held for
+            // good and every later movie sync is refused until Emby restarts. The series
+            // WaitAsync below throws on a cancelled token, and Plugin.Instance.Configuration
+            // throws when ApplicationPaths is not initialised yet, so both sit inside.
             var seriesGateHeld = false;
-            if (needsSeriesGate)
-            {
-                seriesGateHeld = await _seriesSyncGate.WaitAsync(0, cancellationToken).ConfigureAwait(false);
-                if (!seriesGateHeld)
-                {
-                    _movieSyncGate.Release();
-                    _logger.Warn("Retry requested while a series sync is already running — ignoring the duplicate request");
-                    return false;
-                }
-            }
-
-            // Everything after the acquire must be inside the try. Plugin.Instance.Configuration
-            // can throw (ApplicationPaths may not be initialised yet), and a throw between the
-            // acquire and the try would hold the gate forever — every later movie sync would be
-            // refused until Emby restarts.
+            var retryStarted = false;
             try
             {
+                // A retry batch can contain series items, and those write episodes under Shows.
+                // Without the series gate a concurrent series sync would not have the
+                // retry-written paths in its valid set, so its orphan cleanup would delete them —
+                // and they would pass the ownership check precisely because the retry wrote them.
+                if (items.Any(i => i.ItemType == "Series"))
+                {
+                    seriesGateHeld = await _seriesSyncGate.WaitAsync(0, cancellationToken).ConfigureAwait(false);
+                    if (!seriesGateHeld)
+                    {
+                        _logger.Warn("Retry requested while a series sync is already running — ignoring the duplicate request");
+                        return false;
+                    }
+                }
+
                 var config = Plugin.Instance.Configuration;
                 _movieProgress = new SyncProgress { IsRunning = true, Phase = "Retrying failed items", Total = items.Count };
+                retryStarted = true;
 
                 var semaphore = new SemaphoreSlim(ResolveSyncParallelism(config));
                 var categoryNames = new Dictionary<int, string>();
@@ -1440,8 +1440,15 @@ namespace Emby.Xtream.Plugin.Service
             }
             finally
             {
-                _movieProgress.IsRunning = false;
-                _movieProgress.Phase = "Retry complete";
+                // Only report a finished retry if one actually started. Bailing out because the
+                // series gate was taken leaves the previous run's progress object in place, and
+                // stamping "Retry complete" on it would describe a run that never happened.
+                if (retryStarted)
+                {
+                    _movieProgress.IsRunning = false;
+                    _movieProgress.Phase = "Retry complete";
+                }
+
                 if (seriesGateHeld)
                 {
                     _seriesSyncGate.Release();

--- a/Emby.Xtream.Plugin/Service/StrmSyncService.cs
+++ b/Emby.Xtream.Plugin/Service/StrmSyncService.cs
@@ -136,10 +136,10 @@ namespace Emby.Xtream.Plugin.Service
         private readonly SemaphoreSlim _seriesSyncGate = new SemaphoreSlim(1, 1);
 
         /// <summary>Lowest usable value for <see cref="PluginConfiguration.SyncParallelism"/>.</summary>
-        internal const int MinSyncParallelism = 1;
+        private const int MinSyncParallelism = 1;
 
         /// <summary>Highest usable value for <see cref="PluginConfiguration.SyncParallelism"/>.</summary>
-        internal const int MaxSyncParallelism = 10;
+        private const int MaxSyncParallelism = 10;
 
         /// <summary>
         /// Returns a usable parallelism, correcting a persisted value that is out of range.
@@ -2106,9 +2106,8 @@ namespace Emby.Xtream.Plugin.Service
                     // proof of ownership: without this a user's own "Ben-Hur" folder would be
                     // destroyed by excluding the provider's "Ben-Hur", and a hand-written .nfo or a
                     // trailer.strm sitting beside our output would go with it. See ADR-014.
-                    bool folderGone;
                     var deletedFiles = StrmOwnership.DeleteOwnedFiles(
-                        existingDir, config.BaseUrl, config.DispatcharrUrl, out folderGone);
+                        existingDir, config.BaseUrl, config.DispatcharrUrl, out var folderGone);
 
                     if (deletedFiles == 0)
                     {

--- a/Emby.Xtream.Plugin/Service/StrmSyncService.cs
+++ b/Emby.Xtream.Plugin/Service/StrmSyncService.cs
@@ -622,7 +622,7 @@ namespace Emby.Xtream.Plugin.Service
                 {
                     _movieProgress.Phase = "Cleaning up orphaned files";
                     var moviesRoot = Path.Combine(config.StrmLibraryPath, "Movies");
-                    _movieProgress.Deleted += CleanupOrphans(moviesRoot, writtenPaths, config.OrphanSafetyThreshold);
+                    _movieProgress.Deleted += CleanupOrphans(moviesRoot, writtenPaths, config.OrphanSafetyThreshold, config);
                 }
 
                 // Persist the highest Added timestamp seen so next sync can delta from here.
@@ -1170,7 +1170,7 @@ namespace Emby.Xtream.Plugin.Service
                 {
                     _seriesProgress.Phase = "Cleaning up orphaned files";
                     var showsRoot = Path.Combine(config.StrmLibraryPath, "Shows");
-                    var deletedEpisodes = CleanupOrphans(showsRoot, writtenPaths, config.OrphanSafetyThreshold);
+                    var deletedEpisodes = CleanupOrphans(showsRoot, writtenPaths, config.OrphanSafetyThreshold, config);
                     _seriesProgress.Deleted += deletedEpisodes;
                     _episodeProgress.Deleted = deletedEpisodes;
                 }
@@ -1956,32 +1956,23 @@ namespace Emby.Xtream.Plugin.Service
 
                 try
                 {
-                    // Ownership check: a folder holding no STRM was not written by this plugin.
-                    // Matching is by title alone, so without this a user's own "Ben-Hur" folder
-                    // would be destroyed by excluding the provider's "Ben-Hur".
-                    var strmFiles = Directory.GetFiles(existingDir, "*.strm", SearchOption.AllDirectories);
-                    if (strmFiles.Length == 0)
+                    // Delete only the files this plugin actually wrote, verified by content, then
+                    // prune whatever that emptied. Matching is by title alone, so a match is not
+                    // proof of ownership: without this a user's own "Ben-Hur" folder would be
+                    // destroyed by excluding the provider's "Ben-Hur", and a hand-written .nfo or a
+                    // trailer.strm sitting beside our output would go with it. See ADR-014.
+                    bool folderGone;
+                    var deletedFiles = StrmOwnership.DeleteOwnedFiles(
+                        existingDir, config.BaseUrl, config.DispatcharrUrl, out folderGone);
+
+                    if (deletedFiles == 0)
                     {
                         _logger.Debug(
-                            "Skipping '{0}' for excluded item '{1}': no STRM files, so this folder isn't ours",
+                            "Skipping '{0}' for excluded item '{1}': nothing in it was written by this plugin",
                             existingDir, sanitized);
                         continue;
                     }
 
-                    // Delete only what we wrote, then prune whatever that emptied. Anything the
-                    // user put alongside it survives, and so does the folder if it still holds
-                    // content. Same contract as CleanupOrphans.
-                    foreach (var file in Directory.GetFiles(existingDir, "*.*", SearchOption.AllDirectories))
-                    {
-                        var ext = Path.GetExtension(file);
-                        if (string.Equals(ext, ".strm", StringComparison.OrdinalIgnoreCase)
-                            || string.Equals(ext, ".nfo", StringComparison.OrdinalIgnoreCase))
-                        {
-                            File.Delete(file);
-                        }
-                    }
-
-                    var folderGone = TryPruneEmptyTree(existingDir);
                     dirIndex.Remove(sanitized);
                     removed++;
                     _logger.Info(
@@ -2005,34 +1996,9 @@ namespace Emby.Xtream.Plugin.Service
             return removed;
         }
 
-        /// <summary>
-        /// Deletes <paramref name="dir"/> and any subdirectory of it that is empty, deepest first.
-        /// Stops at the first level that still holds something.
-        /// </summary>
-        /// <param name="dir">The directory to prune.</param>
-        /// <returns>True if <paramref name="dir"/> itself was removed.</returns>
-        private static bool TryPruneEmptyTree(string dir)
-        {
-            if (!Directory.Exists(dir))
-            {
-                return true;
-            }
 
-            foreach (var sub in Directory.GetDirectories(dir))
-            {
-                TryPruneEmptyTree(sub);
-            }
-
-            if (Directory.GetFileSystemEntries(dir).Length == 0)
-            {
-                Directory.Delete(dir);
-                return true;
-            }
-
-            return false;
-        }
-
-        private int CleanupOrphans(string rootPath, HashSet<string> validPaths, double safetyThreshold)
+        private int CleanupOrphans(
+            string rootPath, HashSet<string> validPaths, double safetyThreshold, PluginConfiguration config)
         {
             if (!Directory.Exists(rootPath))
             {
@@ -2040,12 +2006,11 @@ namespace Emby.Xtream.Plugin.Service
             }
 
             var existingStrms = Directory.GetFiles(rootPath, "*.strm", SearchOption.AllDirectories);
-            var orphanCount = existingStrms.Count(s => !validPaths.Contains(s));
 
             // Nothing was written or preserved this run, but files exist on disk. That is a
             // provider returning an empty catalogue, not the user deleting their whole library.
             // The ratio guard below cannot catch this at small N (it only applies above 10 files),
-            // so refuse outright rather than emptying the library.
+            // so refuse outright rather than emptying the library. See ADR-013.
             if (validPaths.Count == 0 && existingStrms.Length > 0)
             {
                 _logger.Warn(
@@ -2054,43 +2019,62 @@ namespace Emby.Xtream.Plugin.Service
                 return 0;
             }
 
-            if (safetyThreshold > 0 && existingStrms.Length > 10 && orphanCount > 0)
+            // Being a .strm under our library root is not proof we wrote it. Verify ownership
+            // before considering anything for deletion — a user's own STRM that the provider
+            // never listed would otherwise look exactly like an orphan. Only orphan candidates
+            // are read, so the cost stays proportional to deletions, not to library size.
+            var orphans = existingStrms
+                .Where(s => !validPaths.Contains(s))
+                .Where(s => StrmOwnership.IsOwnedStrm(s, config.BaseUrl, config.DispatcharrUrl))
+                .ToList();
+
+            var foreignCount = existingStrms.Length - validPaths.Count - orphans.Count;
+            if (foreignCount > 0)
             {
-                double ratio = (double)orphanCount / existingStrms.Length;
+                _logger.Info(
+                    "Orphan cleanup: leaving {0} STRM file(s) under {1} that this plugin did not write",
+                    foreignCount, rootPath);
+            }
+
+            // Ratio is taken over the files we could actually have written (what we wrote or kept,
+            // plus the orphans we own). Counting foreign files in the denominator would dilute the
+            // ratio and make the guard fire less often than intended.
+            var ownedTotal = validPaths.Count + orphans.Count;
+            if (safetyThreshold > 0 && ownedTotal > 10 && orphans.Count > 0)
+            {
+                double ratio = (double)orphans.Count / ownedTotal;
                 if (ratio > safetyThreshold)
                 {
                     _logger.Warn(
                         "Orphan cleanup skipped: {0}/{1} ({2:P0}) exceeds safety threshold {3:P0} — possible provider issue",
-                        orphanCount, existingStrms.Length, ratio, safetyThreshold);
+                        orphans.Count, ownedTotal, ratio, safetyThreshold);
                     return 0;
                 }
             }
+
             var removed = 0;
 
-            foreach (var strmFile in existingStrms)
+            foreach (var strmFile in orphans)
             {
-                if (!validPaths.Contains(strmFile))
+                try
                 {
-                    try
-                    {
-                        File.Delete(strmFile);
-                        removed++;
+                    File.Delete(strmFile);
+                    removed++;
 
-                        // Remove empty parent directories
-                        var dir = Path.GetDirectoryName(strmFile);
-                        while (!string.IsNullOrEmpty(dir) &&
-                               !string.Equals(dir, rootPath, StringComparison.OrdinalIgnoreCase) &&
-                               Directory.Exists(dir) &&
-                               Directory.GetFileSystemEntries(dir).Length == 0)
-                        {
-                            Directory.Delete(dir);
-                            dir = Path.GetDirectoryName(dir);
-                        }
-                    }
-                    catch (Exception ex)
+                    // Remove empty parent directories
+                    var dir = Path.GetDirectoryName(strmFile);
+                    while (!string.IsNullOrEmpty(dir) &&
+                           !string.Equals(dir, rootPath, StringComparison.OrdinalIgnoreCase) &&
+                           Directory.Exists(dir) &&
+                           Directory.GetFileSystemEntries(dir).Length == 0)
                     {
-                        _logger.Debug("Failed to cleanup orphan '{0}': {1}", strmFile, ex.Message);
+                        Directory.Delete(dir);
+                        dir = Path.GetDirectoryName(dir);
                     }
+                }
+                catch (Exception ex)
+                {
+                    _logger.Debug("Failed to cleanup orphan '{0}': {1}", strmFile, ex.Message);
                 }
             }
 

--- a/Emby.Xtream.Plugin/Service/StrmSyncService.cs
+++ b/Emby.Xtream.Plugin/Service/StrmSyncService.cs
@@ -322,7 +322,15 @@ namespace Emby.Xtream.Plugin.Service
 
                 // Fetch streams for selected categories
                 _movieProgress.Phase = "Fetching VOD streams";
-                var fetchedStreams = await FetchVodStreamsAsync(config.SelectedVodCategoryIds, config, cancellationToken).ConfigureAwait(false);
+                var vodFetch = await FetchVodStreamsAsync(config.SelectedVodCategoryIds, config, cancellationToken).ConfigureAwait(false);
+                var fetchedStreams = vodFetch.Items;
+
+                if (vodFetch.HadFailures)
+                {
+                    _logger.Warn(
+                        "{0} of {1} VOD categories failed to answer — orphan cleanup will be skipped this run to avoid deleting files for the categories that did not report",
+                        vodFetch.FailedCategoryCount, vodFetch.RequestedCategoryCount);
+                }
 
                 // Per-item exclusions (issue #57): split the catalogue before anything else reads it.
                 // The excluded half is kept so its on-disk folders can be removed below.
@@ -607,8 +615,10 @@ namespace Emby.Xtream.Plugin.Service
                         config, excludedMovies, config.MovieFolderMode, categoryNames, folderMappings, "Movies");
                 }
 
-                // Cleanup orphans
-                if (config.CleanupOrphans && _movieProgress.Failed == 0)
+                // Cleanup orphans. Skipped when any category failed to answer: those titles are
+                // missing from writtenPaths through no fault of their own, so deleting what is
+                // "orphaned" would delete a working category's library.
+                if (config.CleanupOrphans && _movieProgress.Failed == 0 && !vodFetch.HadFailures)
                 {
                     _movieProgress.Phase = "Cleaning up orphaned files";
                     var moviesRoot = Path.Combine(config.StrmLibraryPath, "Movies");
@@ -619,6 +629,11 @@ namespace Emby.Xtream.Plugin.Service
                 // Computed over the UNFILTERED catalogue: if the newest movie happens to be
                 // excluded, the watermark must still advance past it or every later sync
                 // re-processes everything after it.
+                //
+                // A partial fetch still advances the watermark. fetchedStreams holds only the
+                // categories that answered, so this moves past what was actually processed;
+                // freezing it because some other category 502'd would make every later sync
+                // re-process the categories that succeeded.
                 if (fetchedStreams.Count > 0)
                 {
                     var maxAdded = fetchedStreams.Max(m => m.Added);
@@ -711,7 +726,15 @@ namespace Emby.Xtream.Plugin.Service
                     : null;
 
                 _seriesProgress.Phase = "Fetching series list";
-                var fetchedSeries = await FetchSeriesListAsync(config.SelectedSeriesCategoryIds, config, cancellationToken).ConfigureAwait(false);
+                var seriesFetch = await FetchSeriesListAsync(config.SelectedSeriesCategoryIds, config, cancellationToken).ConfigureAwait(false);
+                var fetchedSeries = seriesFetch.Items;
+
+                if (seriesFetch.HadFailures)
+                {
+                    _logger.Warn(
+                        "{0} of {1} series categories failed to answer — orphan cleanup will be skipped this run to avoid deleting files for the categories that did not report",
+                        seriesFetch.FailedCategoryCount, seriesFetch.RequestedCategoryCount);
+                }
 
                 // Per-item exclusions (issue #57) — see the matching block in SyncMoviesAsync.
                 var excludedSeriesSet = ContentExclusionFilter.BuildSet(config.ExcludedSeriesIds);
@@ -922,6 +945,26 @@ namespace Emby.Xtream.Plugin.Service
 
                         if (detail == null || detail.Episodes == null || detail.Episodes.Count == 0)
                         {
+                            // An empty payload for a series that already has files on disk is far
+                            // more likely to be a transient provider hiccup (or a tolerated
+                            // malformed episode map, see ADR-010) than a show that genuinely lost
+                            // every episode. Keep the existing files in the valid set and count the
+                            // series as failed, which holds the orphan-cleanup guard below. A real
+                            // removal is picked up by a later run that returns cleanly.
+                            var strandedStrms = FindExistingSeriesStrms(config, subFolder, seriesName);
+                            if (strandedStrms.Length > 0)
+                            {
+                                foreach (var strm in strandedStrms)
+                                {
+                                    lock (writtenPaths) { writtenPaths.Add(strm); }
+                                }
+
+                                _logger.Warn(
+                                    "Series '{0}' (id={1}) returned no episodes but has {2} STRM file(s) on disk — keeping them and skipping orphan cleanup this run",
+                                    series.Name, series.SeriesId, strandedStrms.Length);
+                                Interlocked.Increment(ref _seriesProgress.Failed);
+                            }
+
                             Interlocked.Increment(ref _seriesProgress.Completed);
                             ReportTaskProgress(_seriesProgress, taskProgress);
                             return;
@@ -1121,8 +1164,9 @@ namespace Emby.Xtream.Plugin.Service
                         config, excludedSeriesItems, config.SeriesFolderMode, categoryNames, folderMappings, "Shows");
                 }
 
-                // Cleanup orphans
-                if (config.CleanupOrphans && _seriesProgress.Failed == 0)
+                // Cleanup orphans. Skipped when any category failed to answer — see the
+                // matching block in SyncMoviesAsync.
+                if (config.CleanupOrphans && _seriesProgress.Failed == 0 && !seriesFetch.HadFailures)
                 {
                     _seriesProgress.Phase = "Cleaning up orphaned files";
                     var showsRoot = Path.Combine(config.StrmLibraryPath, "Shows");
@@ -1612,7 +1656,7 @@ namespace Emby.Xtream.Plugin.Service
             // Fallback: derive categories from series list
             _logger.Info("get_series_categories returned empty, deriving from series list");
             var seriesList = await FetchSeriesListAsync(null, config, cancellationToken).ConfigureAwait(false);
-            return seriesList
+            return seriesList.Items
                 .Where(s => s.CategoryId.HasValue)
                 .GroupBy(s => s.CategoryId.Value)
                 .Select(g => new Category
@@ -1625,14 +1669,17 @@ namespace Emby.Xtream.Plugin.Service
                 .ToList();
         }
 
-        private async Task<List<VodStreamInfo>> FetchVodStreamsAsync(
+        private async Task<CatalogueFetchResult<VodStreamInfo>> FetchVodStreamsAsync(
             int[] categoryIds, PluginConfiguration config, CancellationToken cancellationToken)
         {
+            var result = new CatalogueFetchResult<VodStreamInfo>();
             var allStreams = new List<VodStreamInfo>();
 
             if (categoryIds == null || categoryIds.Length == 0)
             {
-                // Fetch all VOD streams
+                // Fetch all VOD streams. A throw here propagates: the caller's outer catch
+                // aborts the sync before cleanup, which is the correct outcome for the
+                // whole-catalogue request failing.
                 var url = string.Format(
                     CultureInfo.InvariantCulture,
                     "{0}/player_api.php?username={1}&password={2}&action=get_vod_streams",
@@ -1644,6 +1691,7 @@ namespace Emby.Xtream.Plugin.Service
             }
             else
             {
+                result.RequestedCategoryCount = categoryIds.Length;
                 var semaphore = new SemaphoreSlim(config.SyncParallelism);
                 var tasks = categoryIds.Select(async catId =>
                 {
@@ -1668,12 +1716,15 @@ namespace Emby.Xtream.Plugin.Service
                             s.CategoryId = catId;
                         }
 
-                        return streams;
+                        return Tuple.Create(streams, true);
                     }
                     catch (Exception ex)
                     {
+                        // Report the failure rather than returning an empty list. An empty list
+                        // is indistinguishable from an empty category and would let orphan
+                        // cleanup delete this category's existing files.
                         _logger.Warn("Failed to fetch VOD streams for category {0}: {1}", catId, ex.Message);
-                        return new List<VodStreamInfo>();
+                        return Tuple.Create(new List<VodStreamInfo>(), false);
                     }
                     finally
                     {
@@ -1682,21 +1733,30 @@ namespace Emby.Xtream.Plugin.Service
                 });
 
                 var results = await Task.WhenAll(tasks).ConfigureAwait(false);
-                foreach (var result in results)
+                foreach (var r in results)
                 {
-                    allStreams.AddRange(result);
+                    if (r.Item2)
+                    {
+                        allStreams.AddRange(r.Item1);
+                    }
+                    else
+                    {
+                        result.FailedCategoryCount++;
+                    }
                 }
 
                 // Deduplicate by StreamId (first occurrence wins, keeping its assigned category)
                 allStreams = allStreams.GroupBy(s => s.StreamId).Select(g => g.First()).ToList();
             }
 
-            return allStreams;
+            result.Items = allStreams;
+            return result;
         }
 
-        private async Task<List<SeriesInfo>> FetchSeriesListAsync(
+        private async Task<CatalogueFetchResult<SeriesInfo>> FetchSeriesListAsync(
             int[] categoryIds, PluginConfiguration config, CancellationToken cancellationToken)
         {
+            var result = new CatalogueFetchResult<SeriesInfo>();
             var allSeries = new List<SeriesInfo>();
 
             if (categoryIds == null || categoryIds.Length == 0)
@@ -1712,6 +1772,7 @@ namespace Emby.Xtream.Plugin.Service
             }
             else
             {
+                result.RequestedCategoryCount = categoryIds.Length;
                 var semaphore = new SemaphoreSlim(config.SyncParallelism);
                 var tasks = categoryIds.Select(async catId =>
                 {
@@ -1734,12 +1795,13 @@ namespace Emby.Xtream.Plugin.Service
                             s.CategoryId = catId;
                         }
 
-                        return series;
+                        return Tuple.Create(series, true);
                     }
                     catch (Exception ex)
                     {
+                        // See FetchVodStreamsAsync: a failure must not look like an empty category.
                         _logger.Warn("Failed to fetch series for category {0}: {1}", catId, ex.Message);
-                        return new List<SeriesInfo>();
+                        return Tuple.Create(new List<SeriesInfo>(), false);
                     }
                     finally
                     {
@@ -1748,15 +1810,58 @@ namespace Emby.Xtream.Plugin.Service
                 });
 
                 var results = await Task.WhenAll(tasks).ConfigureAwait(false);
-                foreach (var result in results)
+                foreach (var r in results)
                 {
-                    allSeries.AddRange(result);
+                    if (r.Item2)
+                    {
+                        allSeries.AddRange(r.Item1);
+                    }
+                    else
+                    {
+                        result.FailedCategoryCount++;
+                    }
                 }
 
                 allSeries = allSeries.GroupBy(s => s.SeriesId).Select(g => g.First()).ToList();
             }
 
-            return allSeries;
+            result.Items = allSeries;
+            return result;
+        }
+
+        /// <summary>
+        /// Finds the STRM files already on disk for <paramref name="seriesName"/>, if any.
+        /// </summary>
+        /// <remarks>
+        /// Used only on the empty-detail path, so the per-series readdir stays off the hot loop.
+        /// Folder names carry an optional metadata-ID suffix, so the comparison strips it the same
+        /// way the pre-fetch smart-skip index does.
+        /// </remarks>
+        private string[] FindExistingSeriesStrms(PluginConfiguration config, string subFolder, string seriesName)
+        {
+            try
+            {
+                var parent = Path.Combine(config.StrmLibraryPath, subFolder);
+                if (!Directory.Exists(parent))
+                {
+                    return Array.Empty<string>();
+                }
+
+                foreach (var dir in Directory.GetDirectories(parent))
+                {
+                    var stripped = StripFolderIdSuffix(Path.GetFileName(dir));
+                    if (string.Equals(stripped, seriesName, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return Directory.GetFiles(dir, "*.strm", SearchOption.AllDirectories);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.Debug("Could not probe existing STRM files for series '{0}': {1}", seriesName, ex.Message);
+            }
+
+            return Array.Empty<string>();
         }
 
         private async Task<SeriesDetailInfo> FetchSeriesDetailAsync(
@@ -1936,6 +2041,18 @@ namespace Emby.Xtream.Plugin.Service
 
             var existingStrms = Directory.GetFiles(rootPath, "*.strm", SearchOption.AllDirectories);
             var orphanCount = existingStrms.Count(s => !validPaths.Contains(s));
+
+            // Nothing was written or preserved this run, but files exist on disk. That is a
+            // provider returning an empty catalogue, not the user deleting their whole library.
+            // The ratio guard below cannot catch this at small N (it only applies above 10 files),
+            // so refuse outright rather than emptying the library.
+            if (validPaths.Count == 0 && existingStrms.Length > 0)
+            {
+                _logger.Warn(
+                    "Orphan cleanup skipped: the catalogue produced no files this run but {0} STRM file(s) exist under {1} — refusing to treat an empty catalogue as a deletion",
+                    existingStrms.Length, rootPath);
+                return 0;
+            }
 
             if (safetyThreshold > 0 && existingStrms.Length > 10 && orphanCount > 0)
             {

--- a/Emby.Xtream.Plugin/Service/SyncMoviesTask.cs
+++ b/Emby.Xtream.Plugin/Service/SyncMoviesTask.cs
@@ -44,11 +44,17 @@ namespace Emby.Xtream.Plugin.Service
                 return;
             }
             progress.Report(0);
-            await svc.SyncMoviesAsync(
+            var ran = await svc.SyncMoviesAsync(
                 config,
                 cancellationToken,
                 () => Plugin.Instance.SaveConfiguration(),
                 progress).ConfigureAwait(false);
+            if (!ran)
+            {
+                // The IsRunning check above is a fast path; the service holds the real gate.
+                _logger.Info("Movie sync already running — skipping scheduled run.");
+                return;
+            }
             progress.Report(100);
         }
     }

--- a/Emby.Xtream.Plugin/Service/SyncSeriesTask.cs
+++ b/Emby.Xtream.Plugin/Service/SyncSeriesTask.cs
@@ -44,11 +44,17 @@ namespace Emby.Xtream.Plugin.Service
                 return;
             }
             progress.Report(0);
-            await svc.SyncSeriesAsync(
+            var ran = await svc.SyncSeriesAsync(
                 config,
                 cancellationToken,
                 () => Plugin.Instance.SaveConfiguration(),
                 progress).ConfigureAwait(false);
+            if (!ran)
+            {
+                // The IsRunning check above is a fast path; the service holds the real gate.
+                _logger.Info("Series sync already running — skipping scheduled run.");
+                return;
+            }
             progress.Report(100);
         }
     }

--- a/Emby.Xtream.Plugin/Service/XtreamTunerHost.cs
+++ b/Emby.Xtream.Plugin/Service/XtreamTunerHost.cs
@@ -1432,7 +1432,7 @@ namespace Emby.Xtream.Plugin.Service
                 ? "ts" : "m3u8";
             return (string.Format(CultureInfo.InvariantCulture,
                 "{0}/live/{1}/{2}/{3}.{4}",
-                config.BaseUrl, config.Username, config.Password, streamId, extension), false);
+                config.BaseUrl, Uri.EscapeDataString(config.Username ?? string.Empty), Uri.EscapeDataString(config.Password ?? string.Empty), streamId, extension), false);
         }
 
         private MediaSourceInfo CreateMediaSourceInfo(

--- a/docs/decisions/013-partial-catalogue-cleanup-guard.md
+++ b/docs/decisions/013-partial-catalogue-cleanup-guard.md
@@ -1,0 +1,96 @@
+# ADR-013: Incomplete Provider Data Must Never Drive Deletion
+
+**Date**: 2026-07-31
+**Status**: ACCEPTED
+**Affects**: `StrmSyncService.FetchVodStreamsAsync` / `FetchSeriesListAsync` / `SyncMoviesAsync` / `SyncSeriesAsync` / `CleanupOrphans`, `CatalogueFetchResult<T>`
+
+---
+
+## Context
+
+Orphan cleanup decides what to delete by difference: every `.strm` under the library root that is not
+in the set of paths this run wrote or preserved is an orphan, and orphans get deleted. That is correct
+only if the run saw the *whole* catalogue. `OrphanSafetyThreshold` (default 20%) exists to catch the
+case where it did not, by refusing to delete when the orphan ratio is implausibly high.
+
+## Problem
+
+Three paths fed cleanup a catalogue that looked complete but was not. None of them tripped the
+threshold.
+
+**1. A failed category request returned an empty list.** `FetchVodStreamsAsync` and
+`FetchSeriesListAsync` fan out one HTTP request per selected category and wrapped each in
+`catch { return new List<T>(); }`. An empty list from a 502 is indistinguishable from a category that
+is genuinely empty. Every title in the failed category became an orphan and was deleted. With many
+categories selected, one failing category is a small fraction of the library, so the ratio stayed
+comfortably under 20% and the guard never fired.
+
+**2. An empty `get_series_info` payload looked like a show that lost every episode.** The check
+`detail == null || detail.Episodes == null || detail.Episodes.Count == 0` returned early without
+recording anything, so all of that show's existing episode STRMs became orphans. This compounds with
+ADR-010: the tolerant converters deliberately turn malformed provider values into empty/null rather
+than throwing, which is right for parsing but means a garbage payload arrives here as "no episodes".
+
+**3. The ratio guard did not apply below 11 files.** `existingStrms.Length > 10` gated the whole
+check, because a ratio over a handful of files is statistically meaningless. The effect was that
+small libraries had no protection at all: a transient `[]` response deleted everything.
+
+The common shape is that *absence of data was read as data*. The plugin could not distinguish "the
+provider says this is gone" from "the provider did not tell us about this".
+
+## Alternatives considered
+
+### 1. Lower the safety threshold — REJECTED
+
+Does not address it. The threshold is a ratio, and the failure produces a plausible ratio. Lowering it
+enough to catch a single failed category among many would block legitimate cleanup constantly.
+
+### 2. Abort the entire sync when any category fails — REJECTED
+
+Correct on the deletion axis but too blunt. A provider with one persistently flaky category would
+never sync anything again. Writing the categories that succeeded is useful and safe; only *deleting*
+requires complete information.
+
+### 3. Freeze the delta watermark on any failure — REJECTED
+
+Proposed as part of the same fix, and it is wrong. If category 7 fails, freezing the watermark makes
+every later sync re-process categories 1-6 from scratch. That is the exact re-processing failure the
+unfiltered-watermark note in ADR-012 exists to prevent. Completeness is required for deletion, not for
+recording progress on what was actually seen.
+
+## Decision
+
+**Separate "what we fetched" from "did we fetch all of it", and gate only deletion on the latter.**
+
+`CatalogueFetchResult<T>` carries the items plus `FailedCategoryCount`. A category that throws is
+counted, not silently flattened into an empty result.
+
+- **Cleanup** is skipped when `HadFailures` is true, alongside the existing `Failed == 0` guard.
+- **The watermark still advances**, computed over the items that did arrive. A partial fetch records
+  real progress on the categories that answered.
+- **An empty episode payload for a series that already has files on disk** preserves those paths and
+  increments `Failed`, which reuses the existing cleanup guard rather than adding a parallel flag. A
+  show that genuinely lost every episode and owns nothing on disk is not a failure, so it does not
+  block cleanup for unrelated titles.
+- **`validPaths.Count == 0` with files on disk refuses cleanup outright.** A run that produced nothing
+  is never evidence that the user's entire library should be deleted.
+
+The `> 10` ratio gate is **kept**. Removing it looked tempting but breaks legitimate small-library
+cleanup: with one file and one orphan the ratio is 1.0, so cleanup would be skipped forever and the
+user would get a warning on every sync. The empty-catalogue guard closes the actual data-loss path at
+small N without that side effect.
+
+## Consequences
+
+- One flaky category no longer costs the user that category's library. Cleanup resumes automatically
+  on the next run that returns cleanly, so no manual intervention is needed.
+- A provider that fails a category on *every* run means cleanup never runs. Orphans accumulate rather
+  than files being destroyed, which is the correct direction to fail. The warning names the failed
+  category count so the cause is visible in the log.
+- If a user genuinely empties their entire provider selection, cleanup will refuse and they must use
+  the delete-content button. Acceptable: that button exists for exactly this, and the alternative is
+  a transient blip wiping a library.
+- Deletion counts drop in partial-failure runs. That is the point, but it means the dashboard's
+  "Deleted" figure is no longer a reliable signal that cleanup ran; the log is.
+- Regression tests all start with files already on disk. A cleanup test seeded from an empty directory
+  passes trivially, which is precisely why the pre-existing empty-response test missed this.

--- a/docs/decisions/014-content-based-strm-ownership.md
+++ b/docs/decisions/014-content-based-strm-ownership.md
@@ -1,0 +1,111 @@
+# ADR-014: Verify STRM Ownership by Content, Not by a Manifest
+
+**Date**: 2026-07-31
+**Status**: ACCEPTED
+**Affects**: `StrmOwnership`, `StrmSyncService.CleanupOrphans` / `RemoveExcludedContent`, `XtreamTunerApi.DeleteContentFolder`
+
+---
+
+## Context
+
+The plugin deletes files on the user's disk in three places: orphan cleanup, per-item exclusion
+(ADR-012), and the "delete all content" button in config. All three ran against a library root that
+the user may also be putting their own files into.
+
+## Problem
+
+None of the three could tell its own output from the user's.
+
+**Orphan cleanup** treated every `.strm` under the library root as a candidate. A STRM the user wrote
+themselves — pointing at their own NAS, never listed by the provider — is by definition not in
+`validPaths`, so it looked exactly like an orphan and was deleted.
+
+**Per-item exclusion** matched folders by title. ADR-012 already recognised that a title match is not
+proof of ownership and added a guard: skip any matched folder containing no `.strm`. That protects a
+user's own `Ben-Hur` folder, but it is coarse. Once a folder held at least one plugin `.strm`, the
+pass deleted *every* `.strm` and `.nfo` in the tree. A user's `trailer.strm` or hand-written `.nfo`
+sitting beside plugin output went with it, contradicting the code's own comment that "anything the
+user put alongside it survives".
+
+**Delete all content** was `Directory.Delete(root, true)` on the whole `Movies`/`Shows` root, followed
+by recreating it. If `StrmLibraryPath` pointed at a shared library, one button press removed
+everything in it. This is the same class of data loss as BUG-028, reached through a button rather than
+a sync.
+
+## Alternatives considered
+
+### 1. A tracking manifest of every written path — REJECTED
+
+The obvious answer, and what an outside review recommended. Persist every path the plugin writes and
+delete only tracked paths.
+
+Rejected as disproportionate. It needs new persisted state, a migration path, and a rebuild story for
+libraries that already exist (the manifest starts empty, so on first run after upgrade nothing is
+owned and cleanup silently stops). It also has to stay correct across renames, naming-version resyncs
+(ADR-004) and folder-mode changes, each of which rewrites paths. That is a lot of moving parts guarding
+a property the files already carry.
+
+ADR-012 rejected a closely related idea — persisting written paths to infer manual deletions — for
+overlapping reasons. Worth noting the rejection there was about *inferring user intent* from the
+filesystem; this one is about cost and migration risk.
+
+### 2. Marker file or extended attribute per folder — REJECTED
+
+A `.emby-xtream` marker is easy to write but trivially lost: any user reorganisation, copy, or restore
+from a backup that does not preserve dotfiles or xattrs silently unowns the folder. Extended attributes
+do not survive most transfers and are filesystem-dependent.
+
+### 3. Ownership by content prefix — ACCEPTED
+
+The plugin's output already identifies itself. Every STRM it writes is the provider URL it was built
+from:
+
+```
+{BaseUrl}/movie/{user}/{pass}/{id}.{ext}
+{BaseUrl}/series/{user}/{pass}/{id}.{ext}
+{DispatcharrUrl}/proxy/vod/movie/{uuid}?stream_id={id}     (multi-version entries)
+```
+
+A STRM whose content starts with one of the configured hosts is ours. No new state, no migration, and
+it works retroactively on libraries that already exist.
+
+## Decision
+
+**`StrmOwnership.IsOwnedStrm` decides ownership by reading the file and matching its content against
+`BaseUrl` or `DispatcharrUrl`.** Both hosts are checked: multi-version entries point at Dispatcharr,
+so a `BaseUrl`-only check would classify them as foreign and stop cleaning them.
+
+NFOs are matched structurally, because the plugin writes exactly two shapes: `{folderName}.nfo` beside
+its matching `{folderName}.strm`, and `tvshow.nfo` at a series root. An NFO qualifies only if it fits
+one of those relative to an owned STRM. Everything else — a user's `movie.nfo`, a hand-edited episode
+NFO — is foreign.
+
+All three delete paths go through this. `DeleteOwnedFiles` resolves ownership across the whole tree
+*before* deleting anything, since the NFO rule is defined in terms of the STRM files that were there.
+
+**Everything fails safe.** An unreadable, empty, or non-matching file is treated as foreign and kept.
+A false negative costs an orphan that survives; a false positive destroys user data.
+
+Ownership is checked only for files that are already deletion candidates, so orphan cleanup reads a
+number of files proportional to the deletions it is about to make, not to library size.
+
+## Consequences
+
+- A user can keep their own content in the STRM library root and the plugin will not touch it. That
+  was never safe before.
+- Excluding a title removes that title's files and leaves anything the user put in the same folder,
+  which is what ADR-012's remarks already claimed the behaviour was.
+- "Delete all content" now reports how many folders it kept because they held foreign files. A user
+  who expects a clean sweep and sees "kept 3 folders" gets a true statement instead of silent data
+  loss.
+- **Changing `BaseUrl` unowns every previously-written STRM.** They stop being cleaned rather than
+  being deleted, which is the safe direction. ADR-004's naming-version resync already rewrites files
+  after a configuration change of this kind, which re-establishes ownership.
+- The orphan ratio is now taken over `validPaths.Count + ownedOrphans.Count` rather than every STRM on
+  disk. Counting foreign files in the denominator would dilute the ratio and make the ADR-013 safety
+  guard fire less often than intended.
+- Orphan counts drop for anyone whose library contains foreign STRMs. That is the fix working, but it
+  means an existing user may see the "Deleted" figure fall after upgrading.
+- Existing orphan tests seeded placeholder file content (`"orphan"`, `"stream 1"`). Those fixtures were
+  unrealistic — a real plugin-written orphan contains the provider URL — and were updated. The tests
+  that deliberately seed foreign content to assert survival were already correct and are unchanged.


### PR DESCRIPTION
Fixes five issues found in a code quality audit of the sync and delete paths. Four of them can destroy files on a user's disk.

Each fix is its own merge commit, so any one can be reverted without touching the others.

## Incomplete provider data no longer drives deletion

Orphan cleanup works by difference, so it is only correct when the run saw the whole catalogue. Three paths fed it a catalogue that looked complete but was not:

- A failed per-category request was swallowed into an empty list, which is indistinguishable from a category that is genuinely empty. Every title in that category became an orphan and was deleted. One failing category among many stays well under the 20% safety threshold, so the guard never fired.
- An empty `get_series_info` payload looked like a show that had lost every episode, so all of its existing STRMs were deleted.
- The ratio guard was skipped entirely below 11 files, leaving small libraries with no protection against a transient empty response.

Catalogue fetches now report which categories failed and cleanup is gated on that. The delta watermark deliberately is not: freezing it because one category returned 502 would make every later sync re-process the categories that succeeded.

The `> 10` gate on the ratio check is kept on purpose. Removing it means a one-file library has a ratio of 1.0 and never gets cleaned. A separate "this run produced no files at all" guard is what actually closes the data-loss path at small N.

See ADR-013.

## Ownership is verified before anything is deleted

All three delete paths matched by title or by "is a .strm", neither of which proves the plugin wrote the file.

- Orphan cleanup treated every `.strm` under the library root as a candidate, so a STRM the user maintained themselves, pointing at their own NAS and never listed by the provider, looked exactly like an orphan.
- Per-item exclusion already skipped folders holding no `.strm`, which protects a user's own `Ben-Hur` folder. But once a folder held one plugin `.strm` it deleted every `.strm` and `.nfo` in the tree, taking a user's `trailer.strm` or hand-written `.nfo` with it. The code's own comment claimed those survived.
- "Delete all content" was `Directory.Delete(root, true)` on the whole Movies/Shows root. On a shared library path, one button press removed everything in it.

No manifest is needed to fix this. Every STRM the plugin writes contains the provider URL it was built from, so the content is proof of ownership: no new state, no migration, and it works on libraries that already exist. Dispatcharr proxy URLs count too, since multi-version entries point there rather than at the base URL. NFOs are matched structurally against the only two shapes the plugin writes.

Everything fails safe. Unreadable, empty or non-matching means foreign, means kept.

See ADR-014.

## One sync of each kind at a time

The "already running" check was a race. Callers tested `IsRunning` and then called the sync, but the service only marks itself running once inside, so a manual sync and the scheduled task could both pass the check. Two runs then shared the written-path set and the progress object, and whichever finished first cleared `IsRunning` while the other was still writing files.

The service now holds a semaphore for the whole operation and returns whether it actually ran. Movies and series keep separate gates since they write to different roots and are meant to overlap.

## SyncParallelism is clamped

The value is validated in the config UI but lives in XML, so it survives hand edits and migrations. Zero was the dangerous one: a semaphore with no permits meant the first task waited forever and the sync hung, with no way out but editing the file.

## Credentials are escaped in generated URLs

A username or password containing `/`, `?`, `#` or a space produced a broken playback URL. The extra separator changed which path segment the provider saw, and `#` truncated everything after it into a fragment, so affected users got failures with no useful error. All nine sites now escape.

Escaping is a no-op for ordinary credentials, so existing STRM files are not rewritten and no library re-scan is triggered.

## Testing

397 tests pass, up from 358.

Every new cleanup test starts with files already on disk and asserts they survive. A cleanup test seeded from an empty directory passes trivially, which is why the existing empty-response test missed this whole class of bug.

Two things worth flagging in review:

- Several existing orphan tests seeded placeholder content (`"orphan"`, `"stream 1"`). A real plugin-written orphan holds the provider URL, so those fixtures were unrealistic and are now accurate. The tests that deliberately seed foreign content to assert survival were already correct and are untouched.
- `FakeHttpHandler` responded synchronously, so a caller ran to completion before returning its Task and two syncs could never be held in flight together. It now supports an optional gate. Without it the concurrency tests would pass while testing nothing.

## User-visible changes for release notes

Anyone upgrading with foreign `.strm` files in their library will see orphan counts drop, and "delete all content" may now report that it kept folders holding content the plugin did not write. That is the fix working, but it will look like a regression without explanation.

If a user genuinely empties their entire provider selection, cleanup will now refuse and they need to use the delete-content button. That trade is deliberate: the alternative is a transient blip wiping a library.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented overlapping movie, series, and retry synchronizations while preserving accurate progress reporting.
  * Improved handling of partial or empty catalogues to protect existing media.
  * Cleanup now removes only plugin-owned files and safely prunes empty folders.
  * Fixed playback and generated file URLs for credentials containing special characters.
  * Improved credential redaction in logs.

* **Tests**
  * Added comprehensive coverage for synchronization, cleanup safety, URL handling, logging, and file ownership.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->