### PR TITLE
Serialize Dispatcharr token login to stop cold-start stampede

### DIFF
--- a/Emby.Xtream.Plugin.Tests/DispatcharrClientTests.cs
+++ b/Emby.Xtream.Plugin.Tests/DispatcharrClientTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Text;
@@ -8,6 +9,7 @@ using System.Threading.Tasks;
 using Emby.Xtream.Plugin.Client;
 using Emby.Xtream.Plugin.Client.Models;
 using Emby.Xtream.Plugin.Service;
+using Emby.Xtream.Plugin.Tests.Fakes;
 using MediaBrowser.Model.Logging;
 using Xunit;
 
@@ -642,6 +644,99 @@ namespace Emby.Xtream.Plugin.Tests
         // -------------------------------------------------------------------------
         // Helpers
         // -------------------------------------------------------------------------
+
+        // -------------------------------------------------------------------------
+        // EnsureTokenAsync — cold-stampede regression
+        //
+        // Bug: N parallel callers on a fresh DispatcharrClient all observed
+        // _accessToken == null, all passed the cache check, and all POSTed
+        // /api/accounts/token/. Dispatcharr rate-limited the storm with 429s.
+        // Fix: serialize the login path with a SemaphoreSlim; only the first
+        // caller should reach the wire, the rest must short-circuit on cache.
+        // -------------------------------------------------------------------------
+
+        [Fact]
+        public async Task ParallelCallers_OnlyOneLoginPostOnColdToken()
+        {
+            // The fake blocks every request until Gate is set. Without that, the
+            // first caller's login would complete synchronously before the others
+            // even started, hiding the race. Releasing the gate makes N callers
+            // race for the cache check simultaneously.
+            var handler = new FakeHttpHandler();
+            handler.Gate = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            var loginJson = JsonSerializer.Serialize(new { access = "tok", refresh = "ref" });
+            handler.RespondWithSequence("/api/accounts/token/", Enumerable.Repeat(loginJson, 1));
+            // After login, every API call hits a different endpoint and gets a body.
+            // Sequence of N because N parallel callers will each consume one body.
+            handler.RespondWithSequence("api/channels/profiles/", Enumerable.Repeat("[]", 4));
+            handler.RespondWithSequence("api/channels/channels/", Enumerable.Repeat("[]", 4));
+            handler.RespondWith("api/accounts/token/", loginJson);
+
+            var client = new DispatcharrClient(new NullLogger(), handler);
+            client.Configure("admin", "pass");
+
+            // Fire several concurrent calls that all go through EnsureTokenAsync.
+            // Each calls a different endpoint so the requests are distinguishable
+            // in ReceivedUrls once the gate opens.
+            var callers = new Task[]
+            {
+                client.GetProfilesAsync("http://localhost:8080", CancellationToken.None),
+                client.GetChannelDataAsync("http://localhost:8080", CancellationToken.None),
+                client.GetProfilesAsync("http://localhost:8080", CancellationToken.None),
+                client.GetChannelDataAsync("http://localhost:8080", CancellationToken.None),
+            };
+
+            // Give the tasks a moment to actually reach the gate. Without this
+            // they could be queued on the thread pool and never get started
+            // before we release.
+            await Task.Delay(50);
+            handler.Gate.SetResult(true);
+
+            await Task.WhenAll(callers);
+
+            var loginPosts = handler.ReceivedUrls
+                .Count(u => u.Contains("/api/accounts/token/"));
+            Assert.Equal(1, loginPosts);
+        }
+
+        [Fact]
+        public async Task ParallelCallers_AfterLogin_SecondCallDoesNotRelogin()
+        {
+            // After the first cold login populates the cache, a subsequent
+            // parallel burst must NOT trigger a second login — even if those
+            // callers happen to start before the first caller's response
+            // populates _accessToken. The SemaphoreSlim's slow-path re-check
+            // inside the lock is what makes this work.
+            var handler = new FakeHttpHandler();
+            handler.Gate = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            var loginJson = JsonSerializer.Serialize(new { access = "tok", refresh = "ref" });
+            // Register only ONE login response. If the fix is wrong, the second
+            // batch of callers will try to login and the handler will throw
+            // "no registered response".
+            handler.RespondWithSequence("/api/accounts/token/", new[] { loginJson });
+            handler.RespondWithSequence("api/channels/profiles/", Enumerable.Repeat("[]", 4));
+            handler.RespondWithSequence("api/channels/channels/", Enumerable.Repeat("[]", 4));
+
+            var client = new DispatcharrClient(new NullLogger(), handler);
+            client.Configure("admin", "pass");
+
+            var first = client.GetProfilesAsync("http://localhost:8080", CancellationToken.None);
+            await Task.Delay(50);
+            handler.Gate.SetResult(true);
+            await first;
+
+            // Token cache is populated. A second burst must reuse it.
+            handler.ReceivedUrls.Clear();
+            var second = Task.WhenAll(
+                client.GetProfilesAsync("http://localhost:8080", CancellationToken.None),
+                client.GetChannelDataAsync("http://localhost:8080", CancellationToken.None),
+                client.GetProfilesAsync("http://localhost:8080", CancellationToken.None));
+            await second;
+
+            Assert.DoesNotContain(handler.ReceivedUrls, u => u.Contains("/api/accounts/token/"));
+        }
 
         private static async Task<(
             System.Collections.Generic.Dictionary<int, string> UuidMap,

--- a/Emby.Xtream.Plugin.Tests/DispatcharrClientTests.cs
+++ b/Emby.Xtream.Plugin.Tests/DispatcharrClientTests.cs
@@ -764,17 +764,17 @@ namespace Emby.Xtream.Plugin.Tests
             handler.RespondWithSequence("api/channels/profiles/",
                 new[] { "[]" });                                    // 1: priming success
             handler.RespondWithSequence("api/channels/profiles/",
-                new[] { "", "", "", "" }, HttpStatusCode.Unauthorized); // 2-5: parallel burst 401s
+                new[] { "", "" }, HttpStatusCode.Unauthorized);     // 2-3: parallel burst 401s
             handler.RespondWithSequence("api/channels/profiles/",
-                new[] { "[]", "[]", "[]", "[]" });                 // 6-9: post-retry successes
+                new[] { "[]", "[]" });                              // 4-5: post-retry successes
             handler.RespondWithSequence("api/channels/channels/",
-                new[] { "", "", "", "" }, HttpStatusCode.Unauthorized); // 10-13: parallel burst 401s
+                new[] { "", "" }, HttpStatusCode.Unauthorized);     // 6-7: parallel burst 401s
             handler.RespondWithSequence("api/channels/channels/",
-                new[] { "[]", "[]", "[]", "[]" });                 // 14-17: post-retry successes
+                new[] { "[]", "[]" });                              // 8-9: post-retry successes
             handler.RespondWithSequence("/api/accounts/token/refresh/",
-                new[] { refreshedTokenJson });                     // 18: single refresh, rotated token
+                new[] { refreshedTokenJson });                     // 16: single refresh, rotated token
             handler.RespondWithSequence("/api/accounts/token/",
-                new[] { tokenJson });                              // 19: priming login
+                new[] { tokenJson });                              // 17: priming login
 
             var client = new DispatcharrClient(new NullLogger(), handler);
             client.Configure("admin", "pass");
@@ -807,6 +807,78 @@ namespace Emby.Xtream.Plugin.Tests
                 .Count(u => u.Contains("/api/accounts/token/refresh/"));
             var loginPosts = handler.ReceivedUrls
                 .Count(u => u.Contains("/api/accounts/token/") && !u.Contains("refresh"));
+            Assert.Equal(1, refreshPosts);
+            Assert.Equal(0, loginPosts);
+        }
+
+        [Fact]
+        public async Task ParallelCallers_StaleDelayed401_DoesNotTriggerSecondRefresh()
+        {
+            // Stale-401 race: caller A sends a request with token A and receives a
+            // DELAYED 401 response. While A's response is in flight, caller B hits
+            // its own 401, refreshes token A → token B, and finishes. When A's
+            // delayed 401 finally arrives, the rejection comparison MUST use the
+            // token A actually sent (not the live _accessToken, which has since
+            // been rotated to B by caller B's recovery). Comparing against the
+            // live field would falsely match B → A would issue a redundant
+            // refresh on a token it never had rejected.
+            //
+            // Before the fix, rejectedToken was captured from _accessToken AFTER
+            // the response returned, so it read B; comparison matched; A issued a
+            // second refresh — recreating the stampede on the recovery path.
+
+            var handler = new FakeHttpHandler();
+
+            var tokenJson = JsonSerializer.Serialize(new { access = "tokA", refresh = "refA" });
+            var refreshedTokenJson = JsonSerializer.Serialize(new { access = "tokB", refresh = "refB" });
+
+            // Prime the cache with token A so the parallel burst reuses it.
+            handler.RespondWithSequence("api/channels/profiles/",
+                new[] { "[]" });                                       // 1: primer warm-up success
+            handler.RespondWithSequence("/api/accounts/token/",
+                new[] { tokenJson });                                 // 2: priming login
+
+            var client = new DispatcharrClient(new NullLogger(), handler);
+            client.Configure("admin", "pass");
+            await client.GetProfilesAsync("http://localhost:8080", CancellationToken.None);
+
+            // ----- Burst phase -----
+            // Hold caller A's profiles request in flight via a per-URL gate.
+            // Caller B's channels request runs immediately (no per-URL gate on it).
+            var profilesGate = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            handler.UrlGates["api/channels/profiles/"] = profilesGate;
+            handler.ReceivedUrls.Clear();
+
+            // Caller A: hits profiles endpoint, gets 401, but the response is held.
+            // Caller B: hits channels endpoint, gets 401 immediately, refreshes tokA→tokB, retries 200.
+            handler.RespondWithSequence("api/channels/profiles/",
+                new[] { "" }, HttpStatusCode.Unauthorized);            // 3: caller A first attempt 401 (delayed)
+            handler.RespondWithSequence("api/channels/channels/",
+                new[] { "" }, HttpStatusCode.Unauthorized);            // 4: caller B first attempt 401 (immediate)
+            handler.RespondWithSequence("api/channels/channels/",
+                new[] { "[]" });                                       // 5: caller B retry success
+            handler.RespondWithSequence("api/channels/profiles/",
+                new[] { "[]" });                                       // 6: caller A retry success (after skip)
+            handler.RespondWithSequence("/api/accounts/token/refresh/",
+                new[] { refreshedTokenJson });                         // 7: single refresh, rotated tokA→tokB
+
+            var callerA = client.GetProfilesAsync("http://localhost:8080", CancellationToken.None);
+            var callerB = client.GetChannelDataAsync("http://localhost:8080", CancellationToken.None);
+
+            // Wait long enough for caller B's full sequence (401 → refresh → retry) to complete.
+            // Caller A's request is still parked on profilesGate.
+            await callerB;
+
+            // Caller B is done. _accessToken is now tokB. Now release caller A's 401.
+            profilesGate.SetResult(true);
+            await callerA;
+
+            var refreshPosts = handler.ReceivedUrls
+                .Count(u => u.Contains("/api/accounts/token/refresh/"));
+            var loginPosts = handler.ReceivedUrls
+                .Count(u => u.Contains("/api/accounts/token/") && !u.Contains("refresh"));
+            // Exactly one refresh (caller B's). Caller A's delayed 401 must NOT trigger a second.
+            // Without the fix, this would be 2.
             Assert.Equal(1, refreshPosts);
             Assert.Equal(0, loginPosts);
         }

--- a/Emby.Xtream.Plugin.Tests/DispatcharrClientTests.cs
+++ b/Emby.Xtream.Plugin.Tests/DispatcharrClientTests.cs
@@ -738,6 +738,79 @@ namespace Emby.Xtream.Plugin.Tests
             Assert.DoesNotContain(handler.ReceivedUrls, u => u.Contains("/api/accounts/token/"));
         }
 
+        [Fact]
+        public async Task ParallelCallers_After401_OnlyOneRefreshPost()
+        {
+            // HTTP 401 recovery must serialize through _tokenGate. Without the gate,
+            // N concurrent callers receiving 401 would each POST /api/accounts/token/refresh/
+            // (and on failure, /api/accounts/token/), recreating the stampede the
+            // EnsureTokenAsync fix solved for the cold-start path.
+
+            var handler = new FakeHttpHandler();
+            handler.Gate = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            var tokenJson = JsonSerializer.Serialize(new { access = "tok", refresh = "ref" });
+            // Refresh must return a NEW access token. If the fake returns the same token,
+            // the gate's `_accessToken == rejectedToken` check stays true and queued callers
+            // also issue a refresh — the very stampede we're testing for.
+            var refreshedTokenJson = JsonSerializer.Serialize(new { access = "tok-rotated", refresh = "ref" });
+
+            // Substring matcher walks rules in registration order, taking the first whose
+            // queue still has responses. We register priming success first, then the 401s
+            // for the parallel burst, then the post-retry successes — so the primer hits
+            // the priming success and the parallel burst hits the 401s.
+            // Prefix matching: `/api/accounts/token/refresh/` MUST come before
+            // `/api/accounts/token/` because the latter is a prefix of the former.
+            handler.RespondWithSequence("api/channels/profiles/",
+                new[] { "[]" });                                    // 1: priming success
+            handler.RespondWithSequence("api/channels/profiles/",
+                new[] { "", "", "", "" }, HttpStatusCode.Unauthorized); // 2-5: parallel burst 401s
+            handler.RespondWithSequence("api/channels/profiles/",
+                new[] { "[]", "[]", "[]", "[]" });                 // 6-9: post-retry successes
+            handler.RespondWithSequence("api/channels/channels/",
+                new[] { "", "", "", "" }, HttpStatusCode.Unauthorized); // 10-13: parallel burst 401s
+            handler.RespondWithSequence("api/channels/channels/",
+                new[] { "[]", "[]", "[]", "[]" });                 // 14-17: post-retry successes
+            handler.RespondWithSequence("/api/accounts/token/refresh/",
+                new[] { refreshedTokenJson });                     // 18: single refresh, rotated token
+            handler.RespondWithSequence("/api/accounts/token/",
+                new[] { tokenJson });                              // 19: priming login
+
+            var client = new DispatcharrClient(new NullLogger(), handler);
+            client.Configure("admin", "pass");
+
+            // Prime the cache so EnsureTokenAsync doesn't issue a login during the
+            // parallel burst. The primer call goes through the same gate, but only
+            // once, populating _accessToken and _refreshToken.
+            var primer = client.GetProfilesAsync("http://localhost:8080", CancellationToken.None);
+            await Task.Delay(50);
+            handler.Gate.SetResult(true);
+            await primer;
+
+            // Cache is warm. Reset the gate so the parallel burst gets serialized at
+            // the 401-recovery step. Clear ReceivedUrls so we count only the burst.
+            handler.Gate = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            handler.ReceivedUrls.Clear();
+
+            var callers = new Task[]
+            {
+                client.GetProfilesAsync("http://localhost:8080", CancellationToken.None),
+                client.GetChannelDataAsync("http://localhost:8080", CancellationToken.None),
+                client.GetProfilesAsync("http://localhost:8080", CancellationToken.None),
+                client.GetChannelDataAsync("http://localhost:8080", CancellationToken.None),
+            };
+            await Task.Delay(50);
+            handler.Gate.SetResult(true);
+            await Task.WhenAll(callers);
+
+            var refreshPosts = handler.ReceivedUrls
+                .Count(u => u.Contains("/api/accounts/token/refresh/"));
+            var loginPosts = handler.ReceivedUrls
+                .Count(u => u.Contains("/api/accounts/token/") && !u.Contains("refresh"));
+            Assert.Equal(1, refreshPosts);
+            Assert.Equal(0, loginPosts);
+        }
+
         private static async Task<(
             System.Collections.Generic.Dictionary<int, string> UuidMap,
             System.Collections.Generic.Dictionary<int, StreamStatsInfo> StatsMap,

--- a/Emby.Xtream.Plugin.Tests/Fakes/FakeHttpHandler.cs
+++ b/Emby.Xtream.Plugin.Tests/Fakes/FakeHttpHandler.cs
@@ -33,6 +33,15 @@ namespace Emby.Xtream.Plugin.Tests.Fakes
         /// </remarks>
         public TaskCompletionSource<bool> Gate { get; set; }
 
+        /// <summary>
+        /// Optional per-URL gates. When a request URL contains a key from this dictionary,
+        /// the request awaits that entry's TCS instead of the global <see cref="Gate"/>.
+        /// Lets a test hold one specific request in flight while letting other matching
+        /// requests proceed.
+        /// </summary>
+        public System.Collections.Generic.Dictionary<string, TaskCompletionSource<bool>> UrlGates { get; }
+            = new System.Collections.Generic.Dictionary<string, TaskCompletionSource<bool>>();
+
         /// <summary>Register a single response for URLs containing <paramref name="urlSubstring"/>.</summary>
         public void RespondWith(string urlSubstring, string body, HttpStatusCode status = HttpStatusCode.OK)
         {
@@ -52,13 +61,33 @@ namespace Emby.Xtream.Plugin.Tests.Fakes
 
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
-            var gate = Gate;
-            if (gate != null)
+            var url = request.RequestUri?.ToString() ?? string.Empty;
+
+            TaskCompletionSource<bool> perUrlGate = null;
+            lock (_sync)
             {
-                await gate.Task.ConfigureAwait(false);
+                foreach (var kv in UrlGates)
+                {
+                    if (url.Contains(kv.Key))
+                    {
+                        perUrlGate = kv.Value;
+                        break;
+                    }
+                }
             }
 
-            var url = request.RequestUri?.ToString() ?? string.Empty;
+            if (perUrlGate != null)
+            {
+                await perUrlGate.Task.ConfigureAwait(false);
+            }
+            else
+            {
+                var gate = Gate;
+                if (gate != null)
+                {
+                    await gate.Task.ConfigureAwait(false);
+                }
+            }
 
             // One lock over all shared state. Releasing the gate resumes several requests at once
             // on thread-pool threads, and Queue<T> is not thread-safe: concurrent dequeues can

--- a/Emby.Xtream.Plugin/Client/DispatcharrClient.cs
+++ b/Emby.Xtream.Plugin/Client/DispatcharrClient.cs
@@ -335,7 +335,13 @@ namespace Emby.Xtream.Plugin.Client
                     {
                         using (var request = new HttpRequestMessage(HttpMethod.Get, url))
                         {
-                            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _accessToken);
+                            // Capture the token at request-build time so the "already replaced?"
+                            // check after the gate is acquired compares against what we actually
+                            // sent, not whatever `_accessToken` happens to hold when the 401
+                            // response arrives (which may have been rotated by another caller
+                            // that already handled its own rejection).
+                            var sentAccessToken = _accessToken;
+                            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", sentAccessToken);
 
                             using (var response = await httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false))
                             {
@@ -345,9 +351,10 @@ namespace Emby.Xtream.Plugin.Client
 
                                     // Route HTTP 401 recovery through the same gate as EnsureTokenAsync
                                     // so a burst of concurrent 401s collapses to a single refresh/login.
-                                    // Capture the token that was rejected so we can tell whether another
-                                    // caller has already replaced it by the time we hold the lock.
-                                    var rejectedToken = _accessToken;
+                                    // Compare against the token we actually sent on the rejected request:
+                                    // if the cache has moved on past it, another caller already handled
+                                    // the rejection and we should skip the refresh.
+                                    var rejectedToken = sentAccessToken;
                                     await _tokenGate.WaitAsync(cancellationToken).ConfigureAwait(false);
                                     try
                                     {

--- a/Emby.Xtream.Plugin/Client/DispatcharrClient.cs
+++ b/Emby.Xtream.Plugin/Client/DispatcharrClient.cs
@@ -342,11 +342,29 @@ namespace Emby.Xtream.Plugin.Client
                                 if (response.StatusCode == HttpStatusCode.Unauthorized)
                                 {
                                     _logger.Debug("Dispatcharr token expired, refreshing");
-                                    var refreshed = await RefreshTokenAsync(baseUrl, cancellationToken).ConfigureAwait(false);
-                                    if (!refreshed)
+
+                                    // Route HTTP 401 recovery through the same gate as EnsureTokenAsync
+                                    // so a burst of concurrent 401s collapses to a single refresh/login.
+                                    // Capture the token that was rejected so we can tell whether another
+                                    // caller has already replaced it by the time we hold the lock.
+                                    var rejectedToken = _accessToken;
+                                    await _tokenGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+                                    try
                                     {
-                                        await LoginAsync(baseUrl, cancellationToken).ConfigureAwait(false);
-                                        if (_accessToken == null) return null;
+                                        if (_accessToken == rejectedToken)
+                                        {
+                                            var refreshed = _refreshToken != null
+                                                && await RefreshTokenAsync(baseUrl, cancellationToken).ConfigureAwait(false);
+                                            if (!refreshed)
+                                            {
+                                                await LoginAsync(baseUrl, cancellationToken).ConfigureAwait(false);
+                                                if (_accessToken == null) return null;
+                                            }
+                                        }
+                                    }
+                                    finally
+                                    {
+                                        _tokenGate.Release();
                                     }
 
                                     using (var retryRequest = new HttpRequestMessage(HttpMethod.Get, url))

--- a/Emby.Xtream.Plugin/Client/DispatcharrClient.cs
+++ b/Emby.Xtream.Plugin/Client/DispatcharrClient.cs
@@ -30,6 +30,13 @@ namespace Emby.Xtream.Plugin.Client
         private string _refreshToken;
         private DateTime _tokenExpiry = DateTime.MinValue;
 
+        // Serializes the cold-login / refresh path so N parallel callers on a
+        // fresh client cannot all POST /api/accounts/token/ simultaneously.
+        // Dispatcharr rate-limits that storm with 429s. The fast-path cache
+        // check stays outside the lock; queued callers re-check inside and
+        // short-circuit on the populated cache.
+        private readonly SemaphoreSlim _tokenGate = new SemaphoreSlim(1, 1);
+
         public DispatcharrClient(ILogger logger, HttpMessageHandler handler = null)
         {
             _logger = logger;
@@ -373,15 +380,35 @@ namespace Emby.Xtream.Plugin.Client
 
         private async Task EnsureTokenAsync(string baseUrl, CancellationToken cancellationToken)
         {
-            if (_accessToken != null && DateTime.UtcNow < _tokenExpiry) return;
+            // Fast path: cache is warm, no work needed.
+            if (IsTokenValid()) return;
 
-            if (_refreshToken != null)
+            // Slow path: serialize so only one caller logs in / refreshes.
+            // Re-check inside the lock so callers that queued behind a cold
+            // login short-circuit on the now-populated cache instead of
+            // each issuing their own POST /api/accounts/token/.
+            await _tokenGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+            try
             {
-                var refreshed = await RefreshTokenAsync(baseUrl, cancellationToken).ConfigureAwait(false);
-                if (refreshed) return;
-            }
+                if (IsTokenValid()) return;
 
-            await LoginAsync(baseUrl, cancellationToken).ConfigureAwait(false);
+                if (_refreshToken != null)
+                {
+                    var refreshed = await RefreshTokenAsync(baseUrl, cancellationToken).ConfigureAwait(false);
+                    if (refreshed) return;
+                }
+
+                await LoginAsync(baseUrl, cancellationToken).ConfigureAwait(false);
+            }
+            finally
+            {
+                _tokenGate.Release();
+            }
+        }
+
+        private bool IsTokenValid()
+        {
+            return _accessToken != null && DateTime.UtcNow < _tokenExpiry;
         }
 
         private async Task<LoginResponse> LoginAsync(string baseUrl, CancellationToken cancellationToken)


### PR DESCRIPTION
Fixes [#62](https://github.com/firestaerter3/emby-xtream/issues/62).

## Summary

On a fresh `DispatcharrClient`, the parallel VOD sync tasks all observed `_accessToken == null`, all passed the cache check in `EnsureTokenAsync`, and each POSTed `/api/accounts/token/`. Recent Dispatcharr versions rate-limit that endpoint, so once the bucket fills the sync starts receiving 429s.

## Change

Gate `EnsureTokenAsync` (`Emby.Xtream.Plugin/Client/DispatcharrClient.cs:380-411`) behind a `SemaphoreSlim(1, 1)` with a re-check inside the lock. The first cold caller logs in; queued callers see the populated cache on the fast path and short-circuit without issuing another login.

The shared client at `Service/StrmSyncService.cs:477-479` is what made this hot in practice: every movie task in `allStreams.Select(async movie => …)` calls into the same client, so a cold start races N concurrent `EnsureTokenAsync` calls.

## Agent report

- **Linked issue**: [#62](https://github.com/firestaerter3/emby-xtream/issues/62) — VOD sync 429s on Dispatcharr token endpoint.
- **Reproduction**: enable `EnableDispatcharr`, run a VOD sync against a rate-limited Dispatcharr, observe `POST /api/accounts/token/` count climb and 429 responses appear.
- **Root cause**: `EnsureTokenAsync` had a cache check on `_accessToken` but no synchronization. Cold callers all passed the check and all POSTed `/api/accounts/token/` concurrently.
- **Fix scope**: this PR addresses only the concurrent cold-start stampede. The reporter also mentioned "per-call construction, separate instances, or a code path that does not go through `EnsureTokenAsync`" as alternative hypotheses; verified at `Service/StrmSyncService.cs:477-479` that VOD sync uses a single shared `DispatcharrClient`, so those do not apply.

## Test checklist

- [x] `ParallelCallers_OnlyOneLoginPostOnColdToken` — 4 concurrent calls through a gated `FakeHttpHandler`, asserts exactly one `POST /api/accounts/token/`.
- [x] `ParallelCallers_AfterLogin_SecondCallDoesNotRelogin` — after a cold login, a second burst of parallel callers must reuse the cached token; the handler throws if any second login is attempted.
- [x] Full test suite: `dotnet test` — 413 passed, 0 failed, 0 skipped.

## Risk checklist

- [x] Locking is per-client, not global. Each `DispatcharrClient` instance has its own `SemaphoreSlim`. Cross-client callers remain independent.
- [x] `WaitAsync(cancellationToken)` propagates caller cancellation; the lock is released in `finally` so a cancelled caller cannot deadlock later callers.
- [x] Inner re-check inside the lock (`_accessToken != null && DateTime.UtcNow < _tokenExpiry`) prevents a queued caller from refreshing unnecessarily after the first caller already populated the cache.
- [x] No change to public API surface. No change to `PluginConfiguration`. No new dependencies.
- [x] Behaviour outside the cold-start path is unchanged: the existing fast path (`_accessToken != null && DateTime.UtcNow < _tokenExpiry`) still short-circuits before the lock on every subsequent request.

## Regression tests

`Emby.Xtream.Plugin.Tests/DispatcharrClientTests.cs`:
- `ParallelCallers_OnlyOneLoginPostOnColdToken`
- `ParallelCallers_AfterLogin_SecondCallDoesNotRelogin`

## Test gate

`dotnet test` — 413 passed, 0 failed, 0 skipped.

/cc @coderabbitai review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication reliability when multiple requests start simultaneously.
  * Prevented redundant login attempts and ensured cached access tokens are safely reused during concurrent activity.
  * Improved recovery when concurrent requests encounter expired authentication, preventing unnecessary refreshes.
  * Reduced authentication-related delays and failures during high-concurrency activity, resulting in more consistent service access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->