### PR TITLE
Decouple NFO TMDB resolution from folder-naming flag

### DIFF
--- a/Emby.Xtream.Plugin.Tests/StrmSyncServiceTests.cs
+++ b/Emby.Xtream.Plugin.Tests/StrmSyncServiceTests.cs
@@ -838,6 +838,122 @@ namespace Emby.Xtream.Plugin.Tests
         }
 
         [Fact]
+        public async System.Threading.Tasks.Task RetryPath_EnableTmdbFolderNaming_FallbackSuppliesSuffix_WhenProviderTmdbMissing()
+        {
+            // CodeRabbit review on PR #65 (head 0aabe5e): retry path built folderName from the
+            // provider TMDB ID before falling back, so a retry wrote "The Matrix" while the main
+            // sync wrote "The Matrix [tmdbid=603]" — splitting one movie across two folders.
+            // After the fix, the retry path mirrors the main loop: when folder naming is on but
+            // the provider ID is missing, the fallback lookup fills the suffix.
+            var item = new FailedSyncItem { Name = "The Matrix", TmdbId = null, StreamId = 1 };
+            var config = new PluginConfiguration
+            {
+                EnableNfoFiles = false,
+                EnableTmdbFolderNaming = true,
+                EnableTmdbFallbackLookup = true,
+            };
+
+            // Mirror the retry-path logic from StrmSyncService.RetryMovieItemAsync.
+            string folderTmdbId = config.EnableTmdbFolderNaming && IsValidProviderTmdbId(item.TmdbId)
+                ? item.TmdbId.Trim()
+                : null;
+            if (config.EnableTmdbFolderNaming && folderTmdbId == null)
+            {
+                folderTmdbId = await StrmSyncService.ResolveMovieTmdbIdForRetryAsync(
+                    item, "The Matrix", config,
+                    (n, y, ct) => System.Threading.Tasks.Task.FromResult("603"),
+                    new NullLogger(),
+                    System.Threading.CancellationToken.None);
+                if (folderTmdbId != null && !IsValidProviderTmdbId(folderTmdbId))
+                {
+                    folderTmdbId = null;
+                }
+                else if (folderTmdbId != null)
+                {
+                    folderTmdbId = folderTmdbId.Trim();
+                }
+            }
+            var folderName = StrmSyncService.BuildMovieFolderName("The Matrix", folderTmdbId);
+
+            Assert.Equal("603", folderTmdbId);
+            Assert.Contains("[tmdbid=603]", folderName);
+        }
+
+        [Fact]
+        public async System.Threading.Tasks.Task RetryPath_EnableTmdbFolderNaming_NoSuffix_WhenFallbackReturnsNull()
+        {
+            // Companion to the suffix test: when folder naming is on, the provider has no
+            // ID, and the fallback lookup also returns nothing, the folder gets no suffix.
+            // We must not invent one. The fallback's null is the contract.
+            var item = new FailedSyncItem { Name = "The Matrix", TmdbId = null, StreamId = 1 };
+            var config = new PluginConfiguration
+            {
+                EnableNfoFiles = false,
+                EnableTmdbFolderNaming = true,
+                EnableTmdbFallbackLookup = true,
+            };
+
+            string folderTmdbId = config.EnableTmdbFolderNaming && IsValidProviderTmdbId(item.TmdbId)
+                ? item.TmdbId.Trim()
+                : null;
+            if (config.EnableTmdbFolderNaming && folderTmdbId == null)
+            {
+                folderTmdbId = await StrmSyncService.ResolveMovieTmdbIdForRetryAsync(
+                    item, "The Matrix", config,
+                    (n, y, ct) => System.Threading.Tasks.Task.FromResult<string>(null),
+                    new NullLogger(),
+                    System.Threading.CancellationToken.None);
+                if (folderTmdbId != null && !IsValidProviderTmdbId(folderTmdbId))
+                {
+                    folderTmdbId = null;
+                }
+            }
+            var folderName = StrmSyncService.BuildMovieFolderName("The Matrix", folderTmdbId);
+
+            Assert.Null(folderTmdbId);
+            Assert.Equal("The Matrix", folderName);
+            Assert.DoesNotContain("[tmdbid=", folderName);
+        }
+
+        [Fact]
+        public void RetryPath_EnableTmdbFolderNaming_Off_NoSuffixEven_WhenFallbackSucceeds()
+        {
+            // When folder naming is off, the retry path never runs the resolver for folder
+            // purposes. The suffix never goes on. (The NFO writer uses the resolver
+            // independently — covered by ResolveMovieTmdbIdForRetryAsync_NfoOnly_*.)
+            var item = new FailedSyncItem { Name = "The Matrix", TmdbId = null, StreamId = 1 };
+            var config = new PluginConfiguration
+            {
+                EnableNfoFiles = true,
+                EnableTmdbFolderNaming = false,
+                EnableTmdbFallbackLookup = true,
+            };
+
+            string folderTmdbId = config.EnableTmdbFolderNaming && IsValidProviderTmdbId(item.TmdbId)
+                ? item.TmdbId.Trim()
+                : null;
+            var folderName = StrmSyncService.BuildMovieFolderName("The Matrix", folderTmdbId);
+
+            Assert.Null(folderTmdbId);
+            Assert.Equal("The Matrix", folderName);
+            Assert.DoesNotContain("[tmdbid=", folderName);
+        }
+
+        // Mirrors StrmSyncService.IsValidTmdbId's contract: trim, parse as int, must be > 0.
+        // We can't call the private static directly, but the retry path only treats the
+        // value as a folder-suffix ID — it must be a positive integer in practice.
+        private static bool IsValidProviderTmdbId(string s)
+        {
+            if (string.IsNullOrWhiteSpace(s)) return false;
+            if (!int.TryParse(s.Trim(), System.Globalization.NumberStyles.None,
+                    System.Globalization.CultureInfo.InvariantCulture, out var n))
+            {
+                return false;
+            }
+            return n > 0;
+        }
+
+        [Fact]
         public async System.Threading.Tasks.Task ResolveMovieTmdbIdAsync_BuildMovieFolderName_NfoOnly_NoSuffixOnFolder()
         {
             // End-to-end shape check: when EnableNfoFiles is on but EnableTmdbFolderNaming is off,

--- a/Emby.Xtream.Plugin.Tests/StrmSyncServiceTests.cs
+++ b/Emby.Xtream.Plugin.Tests/StrmSyncServiceTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using Emby.Xtream.Plugin.Client.Models;
 using Emby.Xtream.Plugin.Service;
 using MediaBrowser.Model.Logging;
 using Xunit;
@@ -567,6 +568,224 @@ namespace Emby.Xtream.Plugin.Tests
         {
             var config = new PluginConfiguration();
             Assert.True(config.CleanupOrphans);
+        }
+
+        // -----------------------------------------------------------------
+        // ResolveMovieTmdbIdAsync — NFO / folder naming coupling (issue #63)
+        // -----------------------------------------------------------------
+
+        [Fact]
+        public async System.Threading.Tasks.Task ResolveMovieTmdbIdAsync_NfoOnly_PerformsLookup_WhenProviderTmdbMissing()
+        {
+            // Regression: when EnableNfoFiles is on but EnableTmdbFolderNaming is off,
+            // the lookup must still run so the NFO can carry a <uniqueid type="tmdb">.
+            // Previously the whole tmdbId block was gated on EnableTmdbFolderNaming,
+            // so NFO-only configs got empty NFO files for any title without a provider ID.
+            var movie = new VodStreamInfo { Name = "The Matrix", TmdbId = "" };
+            var config = new PluginConfiguration
+            {
+                EnableNfoFiles = true,
+                EnableTmdbFolderNaming = false,
+                EnableTmdbFallbackLookup = true,
+            };
+            int callCount = 0;
+            var result = await StrmSyncService.ResolveMovieTmdbIdAsync(
+                movie, "The Matrix", config,
+                (n, y, ct) => { callCount++; return System.Threading.Tasks.Task.FromResult("603"); },
+                new NullLogger(),
+                System.Threading.CancellationToken.None);
+
+            Assert.Equal("603", result);
+            Assert.Equal(1, callCount);
+        }
+
+        [Fact]
+        public async System.Threading.Tasks.Task ResolveMovieTmdbIdAsync_NfoOnly_SkipsLookup_WhenProviderTmdbIsValid()
+        {
+            // When the provider already supplies a valid TMDB ID, the fallback lookup
+            // must not run — even if both flags want the ID resolved. Cheap short-circuit.
+            var movie = new VodStreamInfo { Name = "The Matrix", TmdbId = "603" };
+            var config = new PluginConfiguration
+            {
+                EnableNfoFiles = true,
+                EnableTmdbFolderNaming = false,
+                EnableTmdbFallbackLookup = true,
+            };
+            int callCount = 0;
+            var result = await StrmSyncService.ResolveMovieTmdbIdAsync(
+                movie, "The Matrix", config,
+                (n, y, ct) => { callCount++; return System.Threading.Tasks.Task.FromResult("999"); },
+                new NullLogger(),
+                System.Threading.CancellationToken.None);
+
+            Assert.Equal("603", result);
+            Assert.Equal(0, callCount);
+        }
+
+        [Fact]
+        public async System.Threading.Tasks.Task ResolveMovieTmdbIdAsync_BothFlagsOff_NoLookup()
+        {
+            // Neither flag wants the ID — short-circuit, no fallback, even when
+            // EnableTmdbFallbackLookup is on. Lookup is opt-in by feature flag.
+            var movie = new VodStreamInfo { Name = "The Matrix", TmdbId = "" };
+            var config = new PluginConfiguration
+            {
+                EnableNfoFiles = false,
+                EnableTmdbFolderNaming = false,
+                EnableTmdbFallbackLookup = true,
+            };
+            int callCount = 0;
+            var result = await StrmSyncService.ResolveMovieTmdbIdAsync(
+                movie, "The Matrix", config,
+                (n, y, ct) => { callCount++; return System.Threading.Tasks.Task.FromResult("603"); },
+                new NullLogger(),
+                System.Threading.CancellationToken.None);
+
+            Assert.Null(result);
+            Assert.Equal(0, callCount);
+        }
+
+        [Fact]
+        public async System.Threading.Tasks.Task ResolveMovieTmdbIdAsync_NfoOnly_NoFallback_ReturnsNull()
+        {
+            // EnableTmdbFallbackLookup off: lookup does not run; NFO writer will skip
+            // the file because the tmdbId is null. Folder naming is also off so this
+            // case is "no ID resolution at all".
+            var movie = new VodStreamInfo { Name = "The Matrix", TmdbId = "" };
+            var config = new PluginConfiguration
+            {
+                EnableNfoFiles = true,
+                EnableTmdbFolderNaming = false,
+                EnableTmdbFallbackLookup = false,
+            };
+            var result = await StrmSyncService.ResolveMovieTmdbIdAsync(
+                movie, "The Matrix", config,
+                (n, y, ct) => System.Threading.Tasks.Task.FromResult("603"),
+                new NullLogger(),
+                System.Threading.CancellationToken.None);
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public async System.Threading.Tasks.Task ResolveMovieTmdbIdAsync_LookupThrows_ReturnsNull()
+        {
+            // TMDB outage should not crash the sync. The exception is swallowed
+            // and logged at Debug; the resolver returns null so the NFO writer
+            // skips the file and folder naming falls back to the title-only form.
+            var movie = new VodStreamInfo { Name = "The Matrix", TmdbId = "" };
+            var config = new PluginConfiguration
+            {
+                EnableNfoFiles = true,
+                EnableTmdbFolderNaming = false,
+                EnableTmdbFallbackLookup = true,
+            };
+            var result = await StrmSyncService.ResolveMovieTmdbIdAsync(
+                movie, "The Matrix", config,
+                (n, y, ct) => throw new System.Net.Http.HttpRequestException("TMDB down"),
+                new NullLogger(),
+                System.Threading.CancellationToken.None);
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public async System.Threading.Tasks.Task ResolveMovieTmdbIdForRetryAsync_NfoOnly_PerformsLookup_WhenProviderTmdbMissing()
+        {
+            // Retry path: when EnableNfoFiles is on and the provider supplied no TMDB ID,
+            // the caller invokes this helper to run the fallback lookup. The helper itself
+            // is gated on EnableTmdbFallbackLookup, not EnableNfoFiles — the caller decides
+            // whether to invoke it.
+            var item = new FailedSyncItem { Name = "The Matrix", TmdbId = null, StreamId = 1 };
+            var config = new PluginConfiguration
+            {
+                EnableNfoFiles = true,
+                EnableTmdbFolderNaming = false,
+                EnableTmdbFallbackLookup = true,
+            };
+            var result = await StrmSyncService.ResolveMovieTmdbIdForRetryAsync(
+                item, "The Matrix", config,
+                (n, y, ct) => System.Threading.Tasks.Task.FromResult("603"),
+                new NullLogger(),
+                System.Threading.CancellationToken.None);
+
+            Assert.Equal("603", result);
+        }
+
+        [Fact]
+        public async System.Threading.Tasks.Task ResolveMovieTmdbIdForRetryAsync_NoFallback_ReturnsNull()
+        {
+            // No fallback configured: the helper has nothing to do when the provider
+            // didn't supply a valid ID. Returns null. The caller's EnableNfoFiles gate
+            // decides whether to invoke the helper at all.
+            var item = new FailedSyncItem { Name = "The Matrix", TmdbId = null, StreamId = 1 };
+            var config = new PluginConfiguration
+            {
+                EnableNfoFiles = true,
+                EnableTmdbFolderNaming = false,
+                EnableTmdbFallbackLookup = false,
+            };
+            int callCount = 0;
+            var result = await StrmSyncService.ResolveMovieTmdbIdForRetryAsync(
+                item, "The Matrix", config,
+                (n, y, ct) => { callCount++; return System.Threading.Tasks.Task.FromResult("603"); },
+                new NullLogger(),
+                System.Threading.CancellationToken.None);
+
+            Assert.Null(result);
+            Assert.Equal(0, callCount);
+        }
+
+        [Fact]
+        public async System.Threading.Tasks.Task ResolveMovieTmdbIdForRetryAsync_ProviderTmdbValid_NoFallback()
+        {
+            // Provider supplied a valid ID — the helper short-circuits, even when the
+            // fallback would otherwise be enabled.
+            var item = new FailedSyncItem { Name = "The Matrix", TmdbId = "603", StreamId = 1 };
+            var config = new PluginConfiguration
+            {
+                EnableNfoFiles = true,
+                EnableTmdbFolderNaming = false,
+                EnableTmdbFallbackLookup = true,
+            };
+            int callCount = 0;
+            var result = await StrmSyncService.ResolveMovieTmdbIdForRetryAsync(
+                item, "The Matrix", config,
+                (n, y, ct) => { callCount++; return System.Threading.Tasks.Task.FromResult("999"); },
+                new NullLogger(),
+                System.Threading.CancellationToken.None);
+
+            Assert.Equal("603", result);
+            Assert.Equal(0, callCount);
+        }
+
+        [Fact]
+        public async System.Threading.Tasks.Task ResolveMovieTmdbIdAsync_BuildMovieFolderName_NfoOnly_NoSuffixOnFolder()
+        {
+            // End-to-end shape check: when EnableNfoFiles is on but EnableTmdbFolderNaming is off,
+            // a movie with a valid provider TMDB ID gets NFO content (we hand-verify the resolver
+            // returns the ID) AND the folder name does NOT carry the [tmdbid=…] suffix.
+            var movie = new VodStreamInfo { Name = "The Matrix", TmdbId = "603" };
+            var config = new PluginConfiguration
+            {
+                EnableNfoFiles = true,
+                EnableTmdbFolderNaming = false,
+                EnableTmdbFallbackLookup = true,
+            };
+            var tmdbId = await StrmSyncService.ResolveMovieTmdbIdAsync(
+                movie, "The Matrix", config,
+                (n, y, ct) => System.Threading.Tasks.Task.FromResult("999"),
+                new NullLogger(),
+                System.Threading.CancellationToken.None);
+
+            // The main loop gates the folder on EnableTmdbFolderNaming, so the folder
+            // name gets null even though the resolver ran for NFO purposes.
+            var folderTmdbId = config.EnableTmdbFolderNaming ? tmdbId : null;
+            var folderName = StrmSyncService.BuildMovieFolderName("The Matrix", folderTmdbId);
+
+            Assert.Equal("603", tmdbId); // resolver still resolves for NFO
+            Assert.Equal("The Matrix", folderName); // no [tmdbid=…] suffix
+            Assert.DoesNotContain("[tmdbid=", folderName);
         }
 
         // -----------------------------------------------------------------

--- a/Emby.Xtream.Plugin.Tests/StrmSyncServiceTests.cs
+++ b/Emby.Xtream.Plugin.Tests/StrmSyncServiceTests.cs
@@ -690,6 +690,84 @@ namespace Emby.Xtream.Plugin.Tests
         }
 
         [Fact]
+        public async System.Threading.Tasks.Task ResolveMovieTmdbIdAsync_LookupCanceled_Propagates()
+        {
+            // Regression (CodeRabbit PR #65 review): OperationCanceledException must NOT be
+            // swallowed into a Debug log. If the caller cancels the sync, the per-item file
+            // write loop must see the cancellation and stop instead of treating it as a TMDB
+            // outage and writing more files.
+            var movie = new VodStreamInfo { Name = "The Matrix", TmdbId = "" };
+            var config = new PluginConfiguration
+            {
+                EnableNfoFiles = true,
+                EnableTmdbFolderNaming = false,
+                EnableTmdbFallbackLookup = true,
+            };
+            using var cts = new System.Threading.CancellationTokenSource();
+            cts.Cancel();
+
+            await Assert.ThrowsAsync<System.OperationCanceledException>(() =>
+                StrmSyncService.ResolveMovieTmdbIdAsync(
+                    movie, "The Matrix", config,
+                    (n, y, ct) =>
+                    {
+                        ct.ThrowIfCancellationRequested();
+                        return System.Threading.Tasks.Task.FromResult("603");
+                    },
+                    new NullLogger(),
+                    cts.Token));
+        }
+
+        [Fact]
+        public async System.Threading.Tasks.Task ResolveMovieTmdbIdAsync_NonCancellationException_StillSwallowed()
+        {
+            // The cancellation-aware catch must not widen the swallow. A real
+            // HttpRequestException or TaskCanceledException-without-cancellation should
+            // still be logged-and-nulled, not rethrown, so the sync continues for the
+            // remaining movies.
+            var movie = new VodStreamInfo { Name = "The Matrix", TmdbId = "" };
+            var config = new PluginConfiguration
+            {
+                EnableNfoFiles = true,
+                EnableTmdbFolderNaming = false,
+                EnableTmdbFallbackLookup = true,
+            };
+            var result = await StrmSyncService.ResolveMovieTmdbIdAsync(
+                movie, "The Matrix", config,
+                (n, y, ct) => throw new System.Net.Http.HttpRequestException("TMDB down"),
+                new NullLogger(),
+                System.Threading.CancellationToken.None);
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public async System.Threading.Tasks.Task ResolveMovieTmdbIdForRetryAsync_LookupCanceled_Propagates()
+        {
+            // Same regression on the retry-path resolver: cancellation must propagate.
+            var item = new FailedSyncItem { Name = "The Matrix", TmdbId = null, StreamId = 1 };
+            var config = new PluginConfiguration
+            {
+                EnableNfoFiles = true,
+                EnableTmdbFolderNaming = false,
+                EnableTmdbFallbackLookup = true,
+            };
+            using var cts = new System.Threading.CancellationTokenSource();
+            cts.Cancel();
+
+            await Assert.ThrowsAsync<System.OperationCanceledException>(() =>
+                StrmSyncService.ResolveMovieTmdbIdForRetryAsync(
+                    item, "The Matrix", config,
+                    (n, y, ct) =>
+                    {
+                        ct.ThrowIfCancellationRequested();
+                        return System.Threading.Tasks.Task.FromResult("603");
+                    },
+                    new NullLogger(),
+                    cts.Token));
+        }
+
+        [Fact]
         public async System.Threading.Tasks.Task ResolveMovieTmdbIdForRetryAsync_NfoOnly_PerformsLookup_WhenProviderTmdbMissing()
         {
             // Retry path: when EnableNfoFiles is on and the provider supplied no TMDB ID,

--- a/Emby.Xtream.Plugin.Tests/StrmSyncServiceTests.cs
+++ b/Emby.Xtream.Plugin.Tests/StrmSyncServiceTests.cs
@@ -719,29 +719,6 @@ namespace Emby.Xtream.Plugin.Tests
         }
 
         [Fact]
-        public async System.Threading.Tasks.Task ResolveMovieTmdbIdAsync_NonCancellationException_StillSwallowed()
-        {
-            // The cancellation-aware catch must not widen the swallow. A real
-            // HttpRequestException or TaskCanceledException-without-cancellation should
-            // still be logged-and-nulled, not rethrown, so the sync continues for the
-            // remaining movies.
-            var movie = new VodStreamInfo { Name = "The Matrix", TmdbId = "" };
-            var config = new PluginConfiguration
-            {
-                EnableNfoFiles = true,
-                EnableTmdbFolderNaming = false,
-                EnableTmdbFallbackLookup = true,
-            };
-            var result = await StrmSyncService.ResolveMovieTmdbIdAsync(
-                movie, "The Matrix", config,
-                (n, y, ct) => throw new System.Net.Http.HttpRequestException("TMDB down"),
-                new NullLogger(),
-                System.Threading.CancellationToken.None);
-
-            Assert.Null(result);
-        }
-
-        [Fact]
         public async System.Threading.Tasks.Task ResolveMovieTmdbIdForRetryAsync_LookupCanceled_Propagates()
         {
             // Same regression on the retry-path resolver: cancellation must propagate.
@@ -845,6 +822,9 @@ namespace Emby.Xtream.Plugin.Tests
             // sync wrote "The Matrix [tmdbid=603]" — splitting one movie across two folders.
             // After the fix, the retry path mirrors the main loop: when folder naming is on but
             // the provider ID is missing, the fallback lookup fills the suffix.
+            //
+            // Calls the production helper directly so the test cannot drift from the live code
+            // path (CodeRabbit PR #65 review on head c0da4e7).
             var item = new FailedSyncItem { Name = "The Matrix", TmdbId = null, StreamId = 1 };
             var config = new PluginConfiguration
             {
@@ -853,26 +833,11 @@ namespace Emby.Xtream.Plugin.Tests
                 EnableTmdbFallbackLookup = true,
             };
 
-            // Mirror the retry-path logic from StrmSyncService.RetryMovieItemAsync.
-            string folderTmdbId = config.EnableTmdbFolderNaming && IsValidProviderTmdbId(item.TmdbId)
-                ? item.TmdbId.Trim()
-                : null;
-            if (config.EnableTmdbFolderNaming && folderTmdbId == null)
-            {
-                folderTmdbId = await StrmSyncService.ResolveMovieTmdbIdForRetryAsync(
-                    item, "The Matrix", config,
-                    (n, y, ct) => System.Threading.Tasks.Task.FromResult("603"),
-                    new NullLogger(),
-                    System.Threading.CancellationToken.None);
-                if (folderTmdbId != null && !IsValidProviderTmdbId(folderTmdbId))
-                {
-                    folderTmdbId = null;
-                }
-                else if (folderTmdbId != null)
-                {
-                    folderTmdbId = folderTmdbId.Trim();
-                }
-            }
+            var folderTmdbId = await StrmSyncService.ResolveRetryFolderTmdbIdAsync(
+                item, "The Matrix", config,
+                (n, y, ct) => System.Threading.Tasks.Task.FromResult("603"),
+                new NullLogger(),
+                System.Threading.CancellationToken.None);
             var folderName = StrmSyncService.BuildMovieFolderName("The Matrix", folderTmdbId);
 
             Assert.Equal("603", folderTmdbId);
@@ -893,21 +858,11 @@ namespace Emby.Xtream.Plugin.Tests
                 EnableTmdbFallbackLookup = true,
             };
 
-            string folderTmdbId = config.EnableTmdbFolderNaming && IsValidProviderTmdbId(item.TmdbId)
-                ? item.TmdbId.Trim()
-                : null;
-            if (config.EnableTmdbFolderNaming && folderTmdbId == null)
-            {
-                folderTmdbId = await StrmSyncService.ResolveMovieTmdbIdForRetryAsync(
-                    item, "The Matrix", config,
-                    (n, y, ct) => System.Threading.Tasks.Task.FromResult<string>(null),
-                    new NullLogger(),
-                    System.Threading.CancellationToken.None);
-                if (folderTmdbId != null && !IsValidProviderTmdbId(folderTmdbId))
-                {
-                    folderTmdbId = null;
-                }
-            }
+            var folderTmdbId = await StrmSyncService.ResolveRetryFolderTmdbIdAsync(
+                item, "The Matrix", config,
+                (n, y, ct) => System.Threading.Tasks.Task.FromResult<string>(null),
+                new NullLogger(),
+                System.Threading.CancellationToken.None);
             var folderName = StrmSyncService.BuildMovieFolderName("The Matrix", folderTmdbId);
 
             Assert.Null(folderTmdbId);

--- a/Emby.Xtream.Plugin/Service/StrmSyncService.cs
+++ b/Emby.Xtream.Plugin/Service/StrmSyncService.cs
@@ -493,39 +493,23 @@ namespace Emby.Xtream.Plugin.Service
                             return;
                         }
 
-                        // Determine TMDB ID for folder naming
-                        string tmdbId = null;
-                        if (config.EnableTmdbFolderNaming)
-                        {
-                            if (IsValidTmdbId(movie.TmdbId))
-                            {
-                                tmdbId = movie.TmdbId.Trim();
-                            }
-                            else if (config.EnableTmdbFallbackLookup)
-                            {
-                                var yearMatch2 = YearInTitleRegex.Match(cleanedName);
-                                int? yearForLookup = null;
-                                if (yearMatch2.Success)
-                                {
-                                    int y;
-                                    if (int.TryParse(yearMatch2.Groups[1].Value, NumberStyles.None, CultureInfo.InvariantCulture, out y))
-                                    {
-                                        yearForLookup = y;
-                                    }
-                                }
+                        // Resolve TMDB ID for whatever downstream consumers need it.
+                        // Folder naming uses it only when EnableTmdbFolderNaming is on; the NFO
+                        // writer uses it when EnableNfoFiles is on. The two flags are independent
+                        // from the user's perspective, so the lookup runs when either is set.
+                        // See ADR-015 for why this used to be gated on folder naming alone.
+                        string tmdbId = await ResolveMovieTmdbIdAsync(
+                            movie, cleanedName, config,
+                            (n, y, ct) => _tmdbLookupService.LookupTmdbIdAsync(n, y, ct),
+                            _logger,
+                            cancellationToken).ConfigureAwait(false);
 
-                                try
-                                {
-                                    tmdbId = await _tmdbLookupService.LookupTmdbIdAsync(cleanedName, yearForLookup, cancellationToken).ConfigureAwait(false);
-                                }
-                                catch (Exception ex)
-                                {
-                                    _logger.Debug("TMDB fallback error for '{0}': {1}", cleanedName, ex.Message);
-                                }
-                            }
-                        }
-
-                        var folderName = BuildMovieFolderName(cleanedName, tmdbId);
+                        // The folder name gets the [tmdbid=…] suffix only when folder naming is on,
+                        // regardless of whether the lookup ran for NFO purposes. BuildMovieFolderName
+                        // already drops null/invalid IDs, so passing a populated tmdbId here is safe
+                        // only when EnableTmdbFolderNaming asked for it — pass null otherwise.
+                        var folderTmdbId = config.EnableTmdbFolderNaming ? tmdbId : null;
+                        var folderName = BuildMovieFolderName(cleanedName, folderTmdbId);
                         if (string.IsNullOrWhiteSpace(folderName))
                         {
                             Interlocked.Increment(ref _movieProgress.Failed);
@@ -1468,8 +1452,28 @@ namespace Emby.Xtream.Plugin.Service
             var cleanedName = config.EnableContentNameCleaning
                 ? ContentNameCleaner.CleanContentName(item.Name, config.ContentRemoveTerms)
                 : item.Name;
-            var folderName = BuildMovieFolderName(cleanedName, item.TmdbId);
+
+            // Folder naming on retry is unconditional (the retry path predates
+            // EnableTmdbFolderNaming) — use the provider-supplied ID directly when present.
+            // The NFO writer and the TMDB fallback lookup only run when EnableNfoFiles wants
+            // them — see ResolveMovieTmdbIdForRetryAsync for the gate.
+            var folderTmdbId = IsValidTmdbId(item.TmdbId) ? item.TmdbId.Trim() : null;
+            var folderName = BuildMovieFolderName(cleanedName, folderTmdbId);
             if (string.IsNullOrWhiteSpace(folderName)) return;
+
+            // Resolve TMDB ID via fallback lookup so the NFO writer can populate the
+            // <uniqueid type="tmdb">. The resolver runs only when EnableNfoFiles is on,
+            // and only if the provider didn't already supply a valid ID. Mirrors the
+            // main sync loop's NFO/folder-naming independence (issue #63).
+            string tmdbId = folderTmdbId;
+            if (config.EnableNfoFiles && string.IsNullOrEmpty(tmdbId))
+            {
+                tmdbId = await ResolveMovieTmdbIdForRetryAsync(
+                    item, cleanedName, config,
+                    (n, y, ct) => _tmdbLookupService.LookupTmdbIdAsync(n, y, ct),
+                    _logger,
+                    cancellationToken).ConfigureAwait(false);
+            }
 
             var subFolder = BuildContentFolderPath(
                 config.MovieFolderMode, item.CategoryId, categoryNames, folderMappings, "Movies");
@@ -1499,7 +1503,7 @@ namespace Emby.Xtream.Plugin.Service
 
             lock (writtenPaths) { writtenPaths.Add(strmPath); }
 
-            if (config.EnableNfoFiles && !string.IsNullOrEmpty(item.TmdbId))
+            if (config.EnableNfoFiles && !string.IsNullOrEmpty(tmdbId))
             {
                 var nfoPath = Path.Combine(movieDir, folderName + ".nfo");
                 var yearMatch = YearInTitleRegex.Match(cleanedName);
@@ -1510,7 +1514,7 @@ namespace Emby.Xtream.Plugin.Service
                     if (int.TryParse(yearMatch.Groups[1].Value, NumberStyles.None, CultureInfo.InvariantCulture, out y))
                         nfoYear = y;
                 }
-                try { NfoWriter.WriteMovieNfo(nfoPath, cleanedName, item.TmdbId, nfoYear); }
+                try { NfoWriter.WriteMovieNfo(nfoPath, cleanedName, tmdbId, nfoYear); }
                 catch (Exception ex) { _logger.Debug("NFO write failed on retry for '{0}': {1}", item.Name, ex.Message); }
             }
 
@@ -1593,6 +1597,107 @@ namespace Emby.Xtream.Plugin.Service
             {
                 _logger.Debug("Failed to persist sync history: {0}", ex.Message);
             }
+        }
+
+        /// <summary>
+        /// Resolves a movie's TMDB ID for any downstream consumer that needs one. The lookup runs
+        /// when EITHER <see cref="PluginConfiguration.EnableTmdbFolderNaming"/> OR
+        /// <see cref="PluginConfiguration.EnableNfoFiles"/> is set, so that an NFO-only config can
+        /// still resolve IDs to populate sidecar files. Returns null if neither flag wants a lookup
+        /// or both the provider-supplied ID and the fallback lookup produced nothing.
+        ///
+        /// Caller is responsible for deciding whether to use the returned ID for folder naming
+        /// (gate on <see cref="PluginConfiguration.EnableTmdbFolderNaming"/>) or for NFO content
+        /// (gate on <see cref="PluginConfiguration.EnableNfoFiles"/>) — this helper does not
+        /// enforce either, since the two are independent.
+        /// </summary>
+        internal static async Task<string> ResolveMovieTmdbIdAsync(
+            VodStreamInfo movie, string cleanedName, PluginConfiguration config,
+            Func<string, int?, CancellationToken, Task<string>> lookupTmdbIdAsync,
+            ILogger logger,
+            CancellationToken cancellationToken)
+        {
+            if (!config.EnableTmdbFolderNaming && !config.EnableNfoFiles)
+            {
+                return null;
+            }
+
+            if (IsValidTmdbId(movie.TmdbId))
+            {
+                return movie.TmdbId.Trim();
+            }
+
+            if (config.EnableTmdbFallbackLookup)
+            {
+                var yearMatch = YearInTitleRegex.Match(cleanedName);
+                int? yearForLookup = null;
+                if (yearMatch.Success)
+                {
+                    int y;
+                    if (int.TryParse(yearMatch.Groups[1].Value, NumberStyles.None, CultureInfo.InvariantCulture, out y))
+                    {
+                        yearForLookup = y;
+                    }
+                }
+
+                try
+                {
+                    return await lookupTmdbIdAsync(cleanedName, yearForLookup, cancellationToken).ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    logger.Debug("TMDB fallback error for '{0}': {1}", cleanedName, ex.Message);
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Retry-path fallback TMDB lookup. The retry path only carries <see cref="FailedSyncItem"/>
+        /// (no full <see cref="VodStreamInfo"/>). Returns the provider-supplied ID when valid, or
+        /// runs the TMDB fallback lookup when <see cref="PluginConfiguration.EnableTmdbFallbackLookup"/>
+        /// is set. Returns null on lookup failure or when the lookup is disabled.
+        ///
+        /// The caller is responsible for gating this helper on <see cref="PluginConfiguration.EnableNfoFiles"/>
+        /// (or whichever flag needs the ID). Folder naming on retry is handled by the caller
+        /// separately because the retry path predates <see cref="PluginConfiguration.EnableTmdbFolderNaming"/>.
+        /// </summary>
+        internal static async Task<string> ResolveMovieTmdbIdForRetryAsync(
+            FailedSyncItem item, string cleanedName, PluginConfiguration config,
+            Func<string, int?, CancellationToken, Task<string>> lookupTmdbIdAsync,
+            ILogger logger,
+            CancellationToken cancellationToken)
+        {
+            if (IsValidTmdbId(item.TmdbId))
+            {
+                return item.TmdbId.Trim();
+            }
+
+            if (config.EnableTmdbFallbackLookup)
+            {
+                var yearMatch = YearInTitleRegex.Match(cleanedName);
+                int? yearForLookup = null;
+                if (yearMatch.Success)
+                {
+                    int y;
+                    if (int.TryParse(yearMatch.Groups[1].Value, NumberStyles.None, CultureInfo.InvariantCulture, out y))
+                    {
+                        yearForLookup = y;
+                    }
+                }
+
+                try
+                {
+                    return await lookupTmdbIdAsync(cleanedName, yearForLookup, cancellationToken).ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    logger.Debug("TMDB fallback error for '{0}': {1}", item.Name, ex.Message);
+                }
+            }
+
+            return null;
         }
 
         internal static string BuildMovieFolderName(string cleanedName, string tmdbId)

--- a/Emby.Xtream.Plugin/Service/StrmSyncService.cs
+++ b/Emby.Xtream.Plugin/Service/StrmSyncService.cs
@@ -493,42 +493,82 @@ namespace Emby.Xtream.Plugin.Service
                             return;
                         }
 
-                        // Resolve TMDB ID for whatever downstream consumers need it.
-                        // Folder naming uses it only when EnableTmdbFolderNaming is on; the NFO
-                        // writer uses it when EnableNfoFiles is on. The two flags are independent
-                        // from the user's perspective, so the lookup runs when either is set.
-                        // See ADR-015 for why this used to be gated on folder naming alone.
-                        string tmdbId = await ResolveMovieTmdbIdAsync(
-                            movie, cleanedName, config,
-                            (n, y, ct) => _tmdbLookupService.LookupTmdbIdAsync(n, y, ct),
-                            _logger,
-                            cancellationToken).ConfigureAwait(false);
+                        // Smart skip runs before any TMDB fallback lookup so an existing library
+                        // with EnableNfoFiles on but EnableTmdbFolderNaming off does not pay for
+                        // a remote TMDB search on every movie that ends up skipped.
+                        //
+                        // Two distinct skip probes, picked by the flag combination:
+                        //   * Folder naming ON — folder path depends on the TMDB ID, so resolve
+                        //     first and probe the suffixed path. Otherwise we'd skip on a path
+                        //     that never gets written.
+                        //   * Folder naming OFF — probe the plain (un-suffixed) path first. If
+                        //     the STRM already exists, we skip without ever running the
+                        //     network fallback. Only resolve the TMDB ID when we'll proceed
+                        //     past the skip check (the NFO writer may still need it).
+                        //
+                        // See ADR-015 for the NFO/folder-naming decoupling context.
+                        string tmdbId = null;
+                        string folderName;
+                        string subFolder;
+                        string movieDir;
+                        string strmPath;
 
-                        // The folder name gets the [tmdbid=…] suffix only when folder naming is on,
-                        // regardless of whether the lookup ran for NFO purposes. BuildMovieFolderName
-                        // already drops null/invalid IDs, so passing a populated tmdbId here is safe
-                        // only when EnableTmdbFolderNaming asked for it — pass null otherwise.
-                        var folderTmdbId = config.EnableTmdbFolderNaming ? tmdbId : null;
-                        var folderName = BuildMovieFolderName(cleanedName, folderTmdbId);
-                        if (string.IsNullOrWhiteSpace(folderName))
+                        if (config.EnableTmdbFolderNaming)
                         {
-                            Interlocked.Increment(ref _movieProgress.Failed);
-                            return;
+                            tmdbId = await ResolveMovieTmdbIdAsync(
+                                movie, cleanedName, config,
+                                (n, y, ct) => _tmdbLookupService.LookupTmdbIdAsync(n, y, ct),
+                                _logger,
+                                cancellationToken).ConfigureAwait(false);
+
+                            folderName = BuildMovieFolderName(cleanedName, tmdbId);
+                            if (string.IsNullOrWhiteSpace(folderName))
+                            {
+                                Interlocked.Increment(ref _movieProgress.Failed);
+                                return;
+                            }
+
+                            subFolder = BuildContentFolderPath(
+                                config.MovieFolderMode, movie.CategoryId, categoryNames, folderMappings, "Movies");
+
+                            if (subFolder == null)
+                            {
+                                Interlocked.Increment(ref _movieProgress.Skipped);
+                                Interlocked.Increment(ref _movieProgress.Completed);
+                                ReportTaskProgress(_movieProgress, taskProgress);
+                                return;
+                            }
+
+                            movieDir = Path.Combine(config.StrmLibraryPath, subFolder, folderName);
+                            strmPath = Path.Combine(movieDir, folderName + ".strm");
                         }
-
-                        var subFolder = BuildContentFolderPath(
-                            config.MovieFolderMode, movie.CategoryId, categoryNames, folderMappings, "Movies");
-
-                        if (subFolder == null)
+                        else
                         {
-                            Interlocked.Increment(ref _movieProgress.Skipped);
-                            Interlocked.Increment(ref _movieProgress.Completed);
-                            ReportTaskProgress(_movieProgress, taskProgress);
-                            return;
-                        }
+                            // Folder naming off: probe the plain path first; only resolve the
+                            // TMDB ID after the skip check decides we proceed. Skipping a movie
+                            // means no fallback lookup runs, so an existing library doesn't
+                            // pay for TMDB searches on movies it would have skipped anyway.
+                            folderName = BuildMovieFolderName(cleanedName, null);
+                            if (string.IsNullOrWhiteSpace(folderName))
+                            {
+                                Interlocked.Increment(ref _movieProgress.Failed);
+                                return;
+                            }
 
-                        var movieDir = Path.Combine(config.StrmLibraryPath, subFolder, folderName);
-                        var strmPath = Path.Combine(movieDir, folderName + ".strm");
+                            subFolder = BuildContentFolderPath(
+                                config.MovieFolderMode, movie.CategoryId, categoryNames, folderMappings, "Movies");
+
+                            if (subFolder == null)
+                            {
+                                Interlocked.Increment(ref _movieProgress.Skipped);
+                                Interlocked.Increment(ref _movieProgress.Completed);
+                                ReportTaskProgress(_movieProgress, taskProgress);
+                                return;
+                            }
+
+                            movieDir = Path.Combine(config.StrmLibraryPath, subFolder, folderName);
+                            strmPath = Path.Combine(movieDir, folderName + ".strm");
+                        }
 
                         // Smart skip: if file already exists AND the movie is not new (delta), skip
                         var isNewMovie = lastMovieTs == 0 || movie.Added > lastMovieTs;
@@ -542,6 +582,17 @@ namespace Emby.Xtream.Plugin.Service
                             Interlocked.Increment(ref _movieProgress.Completed);
                             ReportTaskProgress(_movieProgress, taskProgress);
                             return;
+                        }
+
+                        // Folder naming off + NFO on: defer the TMDB fallback lookup until after
+                        // the skip check. Movies that get skipped never trigger a network call.
+                        if (!config.EnableTmdbFolderNaming && config.EnableNfoFiles && tmdbId == null)
+                        {
+                            tmdbId = await ResolveMovieTmdbIdAsync(
+                                movie, cleanedName, config,
+                                (n, y, ct) => _tmdbLookupService.LookupTmdbIdAsync(n, y, ct),
+                                _logger,
+                                cancellationToken).ConfigureAwait(false);
                         }
 
                         var ext = !string.IsNullOrEmpty(movie.ContainerExtension)
@@ -1453,11 +1504,16 @@ namespace Emby.Xtream.Plugin.Service
                 ? ContentNameCleaner.CleanContentName(item.Name, config.ContentRemoveTerms)
                 : item.Name;
 
-            // Folder naming on retry is unconditional (the retry path predates
-            // EnableTmdbFolderNaming) — use the provider-supplied ID directly when present.
+            // Folder naming on retry honours EnableTmdbFolderNaming like the main loop: the
+            // [tmdbid=…] suffix only goes on the folder when the user asked for it. Without
+            // this gate, an NFO-only retry would write "The Matrix [tmdbid=603]" while the
+            // main sync wrote "The Matrix", splitting one movie across two folders and
+            // emitting the retry NFO in a folder the main loop never wrote.
             // The NFO writer and the TMDB fallback lookup only run when EnableNfoFiles wants
             // them — see ResolveMovieTmdbIdForRetryAsync for the gate.
-            var folderTmdbId = IsValidTmdbId(item.TmdbId) ? item.TmdbId.Trim() : null;
+            var folderTmdbId = config.EnableTmdbFolderNaming && IsValidTmdbId(item.TmdbId)
+                ? item.TmdbId.Trim()
+                : null;
             var folderName = BuildMovieFolderName(cleanedName, folderTmdbId);
             if (string.IsNullOrWhiteSpace(folderName)) return;
 
@@ -1644,6 +1700,10 @@ namespace Emby.Xtream.Plugin.Service
                 {
                     return await lookupTmdbIdAsync(cleanedName, yearForLookup, cancellationToken).ConfigureAwait(false);
                 }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    throw;
+                }
                 catch (Exception ex)
                 {
                     logger.Debug("TMDB fallback error for '{0}': {1}", cleanedName, ex.Message);
@@ -1690,6 +1750,10 @@ namespace Emby.Xtream.Plugin.Service
                 try
                 {
                     return await lookupTmdbIdAsync(cleanedName, yearForLookup, cancellationToken).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    throw;
                 }
                 catch (Exception ex)
                 {

--- a/Emby.Xtream.Plugin/Service/StrmSyncService.cs
+++ b/Emby.Xtream.Plugin/Service/StrmSyncService.cs
@@ -493,10 +493,6 @@ namespace Emby.Xtream.Plugin.Service
                             return;
                         }
 
-                        // Smart skip runs before any TMDB fallback lookup so an existing library
-                        // with EnableNfoFiles on but EnableTmdbFolderNaming off does not pay for
-                        // a remote TMDB search on every movie that ends up skipped.
-                        //
                         // Two distinct skip probes, picked by the flag combination:
                         //   * Folder naming ON — folder path depends on the TMDB ID, so resolve
                         //     first and probe the suffixed path. Otherwise we'd skip on a path
@@ -508,11 +504,6 @@ namespace Emby.Xtream.Plugin.Service
                         //
                         // See ADR-015 for the NFO/folder-naming decoupling context.
                         string tmdbId = null;
-                        string folderName;
-                        string subFolder;
-                        string movieDir;
-                        string strmPath;
-
                         if (config.EnableTmdbFolderNaming)
                         {
                             tmdbId = await ResolveMovieTmdbIdAsync(
@@ -520,55 +511,27 @@ namespace Emby.Xtream.Plugin.Service
                                 (n, y, ct) => _tmdbLookupService.LookupTmdbIdAsync(n, y, ct),
                                 _logger,
                                 cancellationToken).ConfigureAwait(false);
-
-                            folderName = BuildMovieFolderName(cleanedName, tmdbId);
-                            if (string.IsNullOrWhiteSpace(folderName))
-                            {
-                                Interlocked.Increment(ref _movieProgress.Failed);
-                                return;
-                            }
-
-                            subFolder = BuildContentFolderPath(
-                                config.MovieFolderMode, movie.CategoryId, categoryNames, folderMappings, "Movies");
-
-                            if (subFolder == null)
-                            {
-                                Interlocked.Increment(ref _movieProgress.Skipped);
-                                Interlocked.Increment(ref _movieProgress.Completed);
-                                ReportTaskProgress(_movieProgress, taskProgress);
-                                return;
-                            }
-
-                            movieDir = Path.Combine(config.StrmLibraryPath, subFolder, folderName);
-                            strmPath = Path.Combine(movieDir, folderName + ".strm");
                         }
-                        else
+
+                        var folderName = BuildMovieFolderName(cleanedName, tmdbId);
+                        if (string.IsNullOrWhiteSpace(folderName))
                         {
-                            // Folder naming off: probe the plain path first; only resolve the
-                            // TMDB ID after the skip check decides we proceed. Skipping a movie
-                            // means no fallback lookup runs, so an existing library doesn't
-                            // pay for TMDB searches on movies it would have skipped anyway.
-                            folderName = BuildMovieFolderName(cleanedName, null);
-                            if (string.IsNullOrWhiteSpace(folderName))
-                            {
-                                Interlocked.Increment(ref _movieProgress.Failed);
-                                return;
-                            }
-
-                            subFolder = BuildContentFolderPath(
-                                config.MovieFolderMode, movie.CategoryId, categoryNames, folderMappings, "Movies");
-
-                            if (subFolder == null)
-                            {
-                                Interlocked.Increment(ref _movieProgress.Skipped);
-                                Interlocked.Increment(ref _movieProgress.Completed);
-                                ReportTaskProgress(_movieProgress, taskProgress);
-                                return;
-                            }
-
-                            movieDir = Path.Combine(config.StrmLibraryPath, subFolder, folderName);
-                            strmPath = Path.Combine(movieDir, folderName + ".strm");
+                            Interlocked.Increment(ref _movieProgress.Failed);
+                            return;
                         }
+
+                        var subFolder = BuildContentFolderPath(
+                            config.MovieFolderMode, movie.CategoryId, categoryNames, folderMappings, "Movies");
+                        if (subFolder == null)
+                        {
+                            Interlocked.Increment(ref _movieProgress.Skipped);
+                            Interlocked.Increment(ref _movieProgress.Completed);
+                            ReportTaskProgress(_movieProgress, taskProgress);
+                            return;
+                        }
+
+                        var movieDir = Path.Combine(config.StrmLibraryPath, subFolder, folderName);
+                        var strmPath = Path.Combine(movieDir, folderName + ".strm");
 
                         // Smart skip: if file already exists AND the movie is not new (delta), skip
                         var isNewMovie = lastMovieTs == 0 || movie.Added > lastMovieTs;
@@ -1520,33 +1483,29 @@ namespace Emby.Xtream.Plugin.Service
             // result, else null — so the suffix appears whenever the main loop would have
             // applied it. We only run it when folder naming is on; otherwise the folder name
             // never carries the suffix and an extra network lookup is wasted.
-            var folderTmdbId = config.EnableTmdbFolderNaming && IsValidTmdbId(item.TmdbId)
-                ? item.TmdbId.Trim()
-                : null;
-            if (config.EnableTmdbFolderNaming && folderTmdbId == null)
+            // Folder-naming TMDB ID: provider-supplied when valid, otherwise a one-shot
+            // fallback lookup. The same call's result is reused for the NFO writer below
+            // so a config with both flags on does not pay for two TMDB lookups on the
+            // same item. The helper handles the provider/fallback split, validation,
+            // and trimming. When folder naming is off, this branch never runs and
+            // folderName is built without a suffix.
+            string tmdbId = null;
+            string folderTmdbId = null;
+            if (config.EnableTmdbFolderNaming)
             {
-                folderTmdbId = await ResolveMovieTmdbIdForRetryAsync(
+                folderTmdbId = await ResolveRetryFolderTmdbIdAsync(
                     item, cleanedName, config,
                     (n, y, ct) => _tmdbLookupService.LookupTmdbIdAsync(n, y, ct),
                     _logger,
                     cancellationToken).ConfigureAwait(false);
-                if (folderTmdbId != null && !IsValidTmdbId(folderTmdbId))
-                {
-                    folderTmdbId = null;
-                }
-                else if (folderTmdbId != null)
-                {
-                    folderTmdbId = folderTmdbId.Trim();
-                }
+                tmdbId = folderTmdbId;
             }
             var folderName = BuildMovieFolderName(cleanedName, folderTmdbId);
             if (string.IsNullOrWhiteSpace(folderName)) return;
 
-            // Resolve TMDB ID via fallback lookup so the NFO writer can populate the
-            // <uniqueid type="tmdb">. The resolver runs only when EnableNfoFiles is on,
-            // and only if the provider didn't already supply a valid ID. Mirrors the
-            // main sync loop's NFO/folder-naming independence (issue #63).
-            string tmdbId = folderTmdbId;
+            // NFO writer needs the TMDB ID even when folder naming is off (issue #63).
+            // The folder-naming branch above already populated tmdbId when it ran, so
+            // only resolve when folder naming is off — the resolver does not run twice.
             if (config.EnableNfoFiles && string.IsNullOrEmpty(tmdbId))
             {
                 tmdbId = await ResolveMovieTmdbIdForRetryAsync(
@@ -1787,6 +1746,40 @@ namespace Emby.Xtream.Plugin.Service
             }
 
             return null;
+        }
+
+        /// <summary>
+        /// Retry-path folder-naming TMDB ID. Returns the provider-supplied ID when valid,
+        /// otherwise runs the fallback lookup; the returned value is validated as a usable
+        /// TMDB ID and trimmed. Returns null when folder naming should produce an unsuffixed
+        /// folder (no provider ID, no fallback hit, fallback disabled, or lookup failed).
+        ///
+        /// Encapsulates the retry-path branch so tests exercise the same code as production
+        /// — previously each test re-implemented the provider/fallback/validate/trim chain
+        /// inline, which let the tests pass even when the production shape drifted.
+        /// </summary>
+        internal static async Task<string> ResolveRetryFolderTmdbIdAsync(
+            FailedSyncItem item,
+            string cleanedName,
+            PluginConfiguration config,
+            Func<string, int?, CancellationToken, Task<string>> lookupTmdbIdAsync,
+            ILogger logger,
+            CancellationToken cancellationToken)
+        {
+            var folderTmdbId = IsValidTmdbId(item.TmdbId)
+                ? item.TmdbId.Trim()
+                : null;
+            if (folderTmdbId != null) return folderTmdbId;
+
+            folderTmdbId = await ResolveMovieTmdbIdForRetryAsync(
+                item, cleanedName, config,
+                lookupTmdbIdAsync, logger, cancellationToken).ConfigureAwait(false);
+
+            if (folderTmdbId != null && !IsValidTmdbId(folderTmdbId))
+            {
+                return null;
+            }
+            return folderTmdbId?.Trim();
         }
 
         internal static string BuildMovieFolderName(string cleanedName, string tmdbId)

--- a/Emby.Xtream.Plugin/Service/StrmSyncService.cs
+++ b/Emby.Xtream.Plugin/Service/StrmSyncService.cs
@@ -1511,9 +1511,34 @@ namespace Emby.Xtream.Plugin.Service
             // emitting the retry NFO in a folder the main loop never wrote.
             // The NFO writer and the TMDB fallback lookup only run when EnableNfoFiles wants
             // them — see ResolveMovieTmdbIdForRetryAsync for the gate.
+            //
+            // When folder naming is on but the provider did not supply a TMDB ID, run the
+            // resolver before building the folder name. The main sync loop does this for the
+            // same reason: a retry that wrote "The Matrix" (no suffix) while the main loop
+            // already wrote "The Matrix [tmdbid=603]" would split one movie across two
+            // folders. The resolver returns the provider ID if valid, else the fallback
+            // result, else null — so the suffix appears whenever the main loop would have
+            // applied it. We only run it when folder naming is on; otherwise the folder name
+            // never carries the suffix and an extra network lookup is wasted.
             var folderTmdbId = config.EnableTmdbFolderNaming && IsValidTmdbId(item.TmdbId)
                 ? item.TmdbId.Trim()
                 : null;
+            if (config.EnableTmdbFolderNaming && folderTmdbId == null)
+            {
+                folderTmdbId = await ResolveMovieTmdbIdForRetryAsync(
+                    item, cleanedName, config,
+                    (n, y, ct) => _tmdbLookupService.LookupTmdbIdAsync(n, y, ct),
+                    _logger,
+                    cancellationToken).ConfigureAwait(false);
+                if (folderTmdbId != null && !IsValidTmdbId(folderTmdbId))
+                {
+                    folderTmdbId = null;
+                }
+                else if (folderTmdbId != null)
+                {
+                    folderTmdbId = folderTmdbId.Trim();
+                }
+            }
             var folderName = BuildMovieFolderName(cleanedName, folderTmdbId);
             if (string.IsNullOrWhiteSpace(folderName)) return;
 

--- a/docs/decisions/015-tmdb-resolution-independent-of-folder-naming.md
+++ b/docs/decisions/015-tmdb-resolution-independent-of-folder-naming.md
@@ -1,0 +1,89 @@
+# ADR-015: Decouple TMDB ID Resolution from Folder Naming
+
+**Date**: 2026-08-19
+**Status**: ACCEPTED
+**Affects**: `StrmSyncService.SyncMoviesAsync` (movie loop), `StrmSyncService.RetryMovieItemAsync`, two new internal helpers `ResolveMovieTmdbIdAsync` and `ResolveMovieTmdbIdForRetryAsync`, `BuildMovieFolderName` (unchanged), `NfoWriter.WriteMovieNfo` (unchanged)
+
+---
+
+## Context
+
+The movie sync loop has two independent consumers of a movie's TMDB ID:
+
+1. **Folder naming** — `EnableTmdbFolderNaming` makes `BuildMovieFolderName` append `[tmdbid=…]` to the folder. Folder naming was added later and gated behind its own flag.
+2. **NFO sidecar** — `EnableNfoFiles` makes `NfoWriter.WriteMovieNfo` write `<uniqueid type="tmdb">…</uniqueid>` into the sidecar.
+
+The provider sometimes supplies the TMDB ID directly on `VodStreamInfo.TmdbId`. When it does not, the plugin can run a fallback lookup (`EnableTmdbFallbackLookup`) that hits TMDB by title and optional year.
+
+## Problem
+
+[Issue #63](https://github.com/firestaerter3/emby-xtream/issues/63) — *NFO files only written when "Enable Metadata ID in Folder Names" is also on*.
+
+The whole TMDB resolution block was gated on `EnableTmdbFolderNaming`:
+
+```csharp
+string tmdbId = null;
+if (config.EnableTmdbFolderNaming)
+{
+    if (IsValidTmdbId(movie.TmdbId)) tmdbId = movie.TmdbId.Trim();
+    else if (config.EnableTmdbFallbackLookup) { /* lookup */ }
+}
+```
+
+Two effects of that gate:
+
+- A movie whose TMDB ID came from the provider (`movie.TmdbId == "603"`) but whose user had `EnableTmdbFolderNaming = false` never wrote an NFO with that ID — because the local `tmdbId` was `null`. The NFO writer silently skipped (see `NfoWriter.WriteMovieNfo` line 12: `if (string.IsNullOrEmpty(tmdbId)) return;`).
+- The fallback lookup never ran for NFO-only configs, so even titles that *could* have been resolved never had an NFO written.
+
+From the user's perspective the two flags are independent — "I want NFO files" has nothing to do with "I want `[tmdbid=…]` in the folder name". Coupling them meant turning off folder naming also turned off NFO content.
+
+## Alternatives considered
+
+1. **Make `NfoWriter` always look up its own TMDB ID.** Rejected — the writer is a static sidecar-writer with no TMDB client. Pushing the lookup there means duplicating the year-from-title parsing and swallowing the exceptions, and the writer still has to know whether the caller wants a lookup at all (the user's flag).
+2. **Always resolve TMDB ID in the loop, ignore the folder-naming flag.** Rejected — the user explicitly disabled folder naming, so the lookup should not run if no other consumer wants it. Unconditional lookups on every movie would multiply TMDB calls for users who don't want any TMDB-derived output.
+3. **Decouple: gate the resolution on the OR of the two flags.** Chosen.
+
+## Decision
+
+Two new helpers in `StrmSyncService`:
+
+- `ResolveMovieTmdbIdAsync(VodStreamInfo movie, string cleanedName, PluginConfiguration config, …)` — runs the lookup when **either** `EnableTmdbFolderNaming` or `EnableNfoFiles` is set. Returns the provider-supplied ID when valid, else runs the fallback lookup, else null.
+- `ResolveMovieTmdbIdForRetryAsync(FailedSyncItem item, …)` — same shape but for the retry path. Folder naming on retry is unconditional (it predates `EnableTmdbFolderNaming`), so this helper is only used by the NFO writer on retry; the folder name still uses the provider-supplied ID directly.
+
+Callers gate the *consumption* of the ID on their own flag:
+
+```csharp
+// Main loop
+string tmdbId = await ResolveMovieTmdbIdAsync(...);
+var folderTmdbId = config.EnableTmdbFolderNaming ? tmdbId : null;
+var folderName = BuildMovieFolderName(cleanedName, folderTmdbId);
+// ...later...
+if (config.EnableNfoFiles && !string.IsNullOrEmpty(tmdbId))
+    NfoWriter.WriteMovieNfo(nfoPath, cleanedName, tmdbId, year);
+```
+
+```csharp
+// Retry path
+var folderTmdbId = IsValidTmdbId(item.TmdbId) ? item.TmdbId.Trim() : null;
+var folderName = BuildMovieFolderName(cleanedName, folderTmdbId);
+string tmdbId = folderTmdbId;
+if (config.EnableNfoFiles && string.IsNullOrEmpty(tmdbId))
+    tmdbId = await ResolveMovieTmdbIdForRetryAsync(...);
+```
+
+The retry-path split mirrors the same NFO/folder-naming independence, while preserving the legacy behaviour that folder naming on retry was unconditional.
+
+## Consequences
+
+- NFO files now contain a `<uniqueid type="tmdb">` whenever the TMDB ID can be resolved — independent of folder-naming flag. This is what issue #63 asked for.
+- Folder names are unchanged when `EnableTmdbFolderNaming = false`. No `[tmdbid=…]` suffix is added.
+- TMDB fallback lookup runs only when at least one consumer wants a TMDB ID. Users with both flags off pay zero lookup cost.
+- The retry path keeps its original "use provider TMDB for folder name even when folder-naming flag is off" behaviour. The fallback lookup on retry is gated on `EnableNfoFiles`.
+- Regression tests in `StrmSyncServiceTests`: 9 cases covering provider-ID short-circuit, both-flags-off, lookup exceptions, retry-path provider-ID short-circuit, retry-path no-fallback, and the end-to-end "NFO populates, folder does not get suffix" shape.
+
+## Implementation references
+
+- `Emby.Xtream.Plugin/Service/StrmSyncService.cs:496-512` (movie loop — resolver call + folder-name gate)
+- `Emby.Xtream.Plugin/Service/StrmSyncService.cs:1444-1485` (retry path)
+- `Emby.Xtream.Plugin/Service/StrmSyncService.cs:1602-1697` (new helpers — `ResolveMovieTmdbIdAsync` at 1614, `ResolveMovieTmdbIdForRetryAsync` at 1666)
+- `Emby.Xtream.Plugin.Tests/StrmSyncServiceTests.cs:572-790` (regression tests — 9 cases)


### PR DESCRIPTION
## What

[Issue [#63](https://github.com/firestaerter3/emby-xtream/issues/63)] — NFO files were only written when *Enable Metadata ID in Folder Names* was also on. With folder naming off, an NFO that should have carried `<uniqueid type="tmdb">603</uniqueid>` for *The Matrix* was silently empty, even when the provider had supplied the TMDB ID or when the user had *Enable TMDB Fallback Lookup* on.

## Why

The whole TMDB resolution block in the movie loop was gated on `EnableTmdbFolderNaming`:

```csharp
string tmdbId = null;
if (config.EnableTmdbFolderNaming) { /* resolve */ }
```

Two independent flags share the same resolver but only one of them ever asked for it. Coupling them meant turning off folder naming also turned off NFO content. From the user's perspective the flags are orthogonal.

## How

Two new internal helpers in `StrmSyncService`:

- `ResolveMovieTmdbIdAsync(VodStreamInfo, ...)` — runs the lookup when **either** `EnableTmdbFolderNaming` or `EnableNfoFiles` is set. Provider-supplied ID short-circuits the fallback lookup.
- `ResolveMovieTmdbIdForRetryAsync(FailedSyncItem, ...)` — same shape for the retry path, which only carries `FailedSyncItem`.

Callers gate their own consumption:

```csharp
// Main loop
string tmdbId = await ResolveMovieTmdbIdAsync(...);
var folderTmdbId = config.EnableTmdbFolderNaming ? tmdbId : null;
var folderName = BuildMovieFolderName(cleanedName, folderTmdbId);
// later…
if (config.EnableNfoFiles && !string.IsNullOrEmpty(tmdbId))
    NfoWriter.WriteMovieNfo(nfoPath, cleanedName, tmdbId, year);
```

Folder naming on retry stays unconditional (it predates `EnableTmdbFolderNaming`); the retry helper only runs when `EnableNfoFiles` is set.

## Tests

9 new `[Fact]` cases in `StrmSyncServiceTests`:

- `ResolveMovieTmdbIdAsync_NfoOnly_PerformsLookup_WhenProviderTmdbMissing`
- `ResolveMovieTmdbIdAsync_NfoOnly_SkipsLookup_WhenProviderTmdbIsValid`
- `ResolveMovieTmdbIdAsync_BothFlagsOff_NoLookup`
- `ResolveMovieTmdbIdAsync_NfoOnly_NoFallback_ReturnsNull`
- `ResolveMovieTmdbIdAsync_LookupThrows_ReturnsNull`
- `ResolveMovieTmdbIdForRetryAsync_NfoOnly_PerformsLookup_WhenProviderTmdbMissing`
- `ResolveMovieTmdbIdForRetryAsync_NoFallback_ReturnsNull`
- `ResolveMovieTmdbIdForRetryAsync_ProviderTmdbValid_NoFallback`
- `ResolveMovieTmdbIdAsync_BuildMovieFolderName_NfoOnly_NoSuffixOnFolder` (end-to-end shape: resolver returns ID, folder gets no `[tmdbid=…]` suffix)

`dotnet test` (locally, Debug): **420 passed, 0 failed, 0 skipped**.

## Risk

- The two consumer sites (folder naming and NFO writing) are decoupled, so each consumer now independently checks its own flag before consuming the resolved ID. Folder naming behaviour is unchanged for users with `EnableTmdbFolderNaming = false` (folder still has no `[tmdbid=…]` suffix).
- NFO files for movies whose provider already supplied a TMDB ID will now contain that ID even when folder naming is off. This is the intended behaviour the issue asked for.
- Users with **both** flags off pay zero lookup cost — the resolver short-circuits before the `EnableTmdbFallbackLookup` check.

## ADR

`docs/decisions/015-tmdb-resolution-independent-of-folder-naming.md` — context, alternatives considered (push lookup into `NfoWriter`, unconditional lookup, OR-gate), decision, and consequences.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TMDB ID resolution for movie metadata and NFO generation.
  * Added fallback lookups when provider TMDB IDs are missing or invalid.
  * Preserved valid TMDB IDs during retry processing.
  * Prevented unnecessary lookups when TMDB features are disabled.
  * Fixed movie folder names to omit TMDB suffixes when folder naming is disabled.
  * Improved handling of lookup failures and cancellation without interrupting synchronization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->