### PR TITLE
Add DispatcharrUseStatsCodec escape route for transcoded stream profiles (#66)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,25 @@ When `SupportsProbing = true` and `AnalyzeDurationMs > 0`, Emby runs ffprobe aga
 
 **Rule**: Always set `SupportsProbing = false` and `AnalyzeDurationMs = 0` for Dispatcharr proxy URLs (`/proxy/ts/stream/{uuid}`), regardless of whether stream stats are available. Direct Xtream URLs (no Dispatcharr) can still use probing when stats are absent.
 
+### The declared video codec comes from the Dispatcharr stream profile
+
+`stream_stats.video_codec` is the codec Dispatcharr **ingested** from the provider, not the one
+it **emits**. On a stream profile that transcodes (HEVC source, H.264 output) declaring it makes
+Emby force the wrong decoder and the channel dies with `Invalid NAL unit` before playback starts.
+
+`XtreamTunerHost.ResolveVideoCodec` therefore asks the channel's stream profile first
+(`StreamProfileCodec` parses `-c:v` and friends out of the profile's ffmpeg parameters), falls
+back to `stream_stats.video_codec` when the profile passes video through or cannot be read, and
+falls back again to `h264`. **No path may declare a null codec**: Emby's
+`RecordingRequiresEncoding` dereferences `MediaStream.Codec`, so a null turns a recording into a
+`NullReferenceException`.
+
+Profile data is fetched on the cached refresh path only (`BuildProfileCodecMapAsync`). Dispatcharr
+lookups at playback time are what BUG-007 was about. `Profile`, `Level`, `BitDepth` and
+`RefFrames` are only declared when the declared codec is the reported one, since they describe the
+ingested codec. `DispatcharrVideoCodecSource` (`auto` / `stats` / `h264` / `hevc`) overrides the
+whole thing. See [ADR-016](docs/decisions/016-dispatcharr-stats-codec-trust.md).
+
 ### SupportsDirectStream controls whether native clients bypass server-side segmentation
 
 `SupportsDirectStream = true` in `MediaSourceInfo` tells Emby the stream can be forwarded directly to the client without transcoding. Native Emby clients (Apple TV, iOS, Android) prefer this path when available — they receive raw MPEG-TS or the proxy URL and play it directly. This skips Emby's HLS segmentation pipeline entirely.

--- a/Emby.Xtream.Plugin.Tests/DispatcharrClientTests.cs
+++ b/Emby.Xtream.Plugin.Tests/DispatcharrClientTests.cs
@@ -241,7 +241,7 @@ namespace Emby.Xtream.Plugin.Tests
                 }
             });
 
-            var (uuidMap, _, _, _, _, _) = await RunGetChannelData(channelsJson);
+            var (uuidMap, _, _, _, _, _, _) = await RunGetChannelData(channelsJson);
 
             Assert.True(uuidMap.ContainsKey(69307), "Config A: UUID must be reachable via Xtream stream_id");
             Assert.Equal("41f6df70-4531-4555-bb13-e4a39c2c242b", uuidMap[69307]);
@@ -264,7 +264,7 @@ namespace Emby.Xtream.Plugin.Tests
                 }
             });
 
-            var (uuidMap, _, _, _, _, _) = await RunGetChannelData(channelsJson);
+            var (uuidMap, _, _, _, _, _, _) = await RunGetChannelData(channelsJson);
 
             Assert.True(uuidMap.ContainsKey(42), "Config B: UUID must be reachable via ch.Id");
             Assert.Equal("uuid-config-b", uuidMap[42]);
@@ -289,7 +289,7 @@ namespace Emby.Xtream.Plugin.Tests
                 }
             });
 
-            var (uuidMap, _, _, _, _, _) = await RunGetChannelData(channelsJson);
+            var (uuidMap, _, _, _, _, _, _) = await RunGetChannelData(channelsJson);
 
             Assert.True(uuidMap.ContainsKey(69307), "Config A key (stream_id) must be present");
             Assert.True(uuidMap.ContainsKey(5398),  "Config B key (ch.Id) must be present");
@@ -331,7 +331,7 @@ namespace Emby.Xtream.Plugin.Tests
                 }
             });
 
-            var (_, statsMap, _, _, _, _) = await RunGetChannelData(channelsJson);
+            var (_, statsMap, _, _, _, _, _) = await RunGetChannelData(channelsJson);
 
             Assert.True(statsMap.ContainsKey(69307), "Stats must be reachable via Xtream stream_id");
             var stats = statsMap[69307];
@@ -362,7 +362,7 @@ namespace Emby.Xtream.Plugin.Tests
                 }
             });
 
-            var (uuidMap, _, _, _, _, _) = await RunGetChannelData(channelsJson);
+            var (uuidMap, _, _, _, _, _, _) = await RunGetChannelData(channelsJson);
 
             Assert.True(uuidMap.ContainsKey(100), "First stream_id must map to UUID");
             Assert.True(uuidMap.ContainsKey(200), "Second stream_id must map to UUID");
@@ -389,7 +389,7 @@ namespace Emby.Xtream.Plugin.Tests
                 }
             });
 
-            var (uuidMap, _, _, _, _, _) = await RunGetChannelData(channelsJson);
+            var (uuidMap, _, _, _, _, _, _) = await RunGetChannelData(channelsJson);
 
             Assert.True(uuidMap.ContainsKey(7), "ch.Id fallback must be written when stream_id is null");
             Assert.Equal("uuid-null-stream-id", uuidMap[7]);
@@ -432,7 +432,7 @@ namespace Emby.Xtream.Plugin.Tests
                 }
             });
 
-            var (uuidMap, _, _, _, _, _) = await RunGetChannelData(channelsJson);
+            var (uuidMap, _, _, _, _, _, _) = await RunGetChannelData(channelsJson);
 
             // Config B: each channel looked up by its own ch.Id
             Assert.Equal("cartoon-uuid", uuidMap[100]);
@@ -452,7 +452,7 @@ namespace Emby.Xtream.Plugin.Tests
                 new { id = 2, uuid = "valid-uuid", name = "OK", streams = new object[0] }
             });
 
-            var (uuidMap, _, _, _, _, _) = await RunGetChannelData(channelsJson);
+            var (uuidMap, _, _, _, _, _, _) = await RunGetChannelData(channelsJson);
 
             Assert.False(uuidMap.ContainsKey(1), "Channel without UUID must be skipped");
             Assert.True(uuidMap.ContainsKey(2));
@@ -496,7 +496,7 @@ namespace Emby.Xtream.Plugin.Tests
                 }
             });
 
-            var (_, statsMap, _, _, _, _) = await RunGetChannelData(channelsJson);
+            var (_, statsMap, _, _, _, _, _) = await RunGetChannelData(channelsJson);
 
             // stream_id=300 gets the first (h264) stats
             Assert.True(statsMap.ContainsKey(300));
@@ -546,7 +546,7 @@ namespace Emby.Xtream.Plugin.Tests
                 }
             });
 
-            var (uuidMap, _, tvgIdMap, stationIdMap, _, _) = await RunGetChannelData(channelsJson);
+            var (uuidMap, _, tvgIdMap, stationIdMap, _, _, _) = await RunGetChannelData(channelsJson);
 
             Assert.Equal(3, uuidMap.Count);
 
@@ -883,13 +883,119 @@ namespace Emby.Xtream.Plugin.Tests
             Assert.Equal(0, loginPosts);
         }
 
+        // -------------------------------------------------------------------------
+        // Stream profiles (issue #66): what the proxy emits, not what it ingested.
+        // -------------------------------------------------------------------------
+
+        [Fact]
+        public async Task GetStreamProfiles_ReturnsProfilesWithCommandAndParameters()
+        {
+            var profilesJson = JsonSerializer.Serialize(new[]
+            {
+                new { id = 1, name = "Proxy", command = "", parameters = "", is_active = true, locked = true },
+                new { id = 2, name = "NVENC", command = "ffmpeg", parameters = "-i {streamUrl} -c:v h264_nvenc -f mpegts pipe:1", is_active = true, locked = false },
+            });
+
+            string requestedPath = null;
+            var handler = new MockHandler(request =>
+            {
+                if (request.RequestUri.AbsolutePath.Contains("/api/accounts/token/"))
+                {
+                    var json = JsonSerializer.Serialize(new { access = "tok", refresh = "ref" });
+                    return new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new StringContent(json, Encoding.UTF8, "application/json")
+                    };
+                }
+                requestedPath = request.RequestUri.AbsolutePath;
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(profilesJson, Encoding.UTF8, "application/json")
+                };
+            });
+
+            var client = CreateClient(handler);
+            client.Configure("admin", "pass");
+            var profiles = await client.GetStreamProfilesAsync("http://localhost:8080", CancellationToken.None);
+
+            Assert.Equal(2, profiles.Count);
+            Assert.Equal("ffmpeg", profiles[1].Command);
+            Assert.Equal("h264", StreamProfileCodec.Parse(profiles[1].Command, profiles[1].Parameters));
+            Assert.Equal("/api/core/streamprofiles/", requestedPath);
+        }
+
+        [Fact]
+        public async Task GetDefaultStreamProfileId_ReadsTheSettingAndIgnoresOtherRows()
+        {
+            // The settings endpoint returns rows of every kind, including JSON blobs, and
+            // types the value loosely — a profile ID arrives as a string on some versions.
+            var settingsJson = "[" +
+                "{\"id\":1,\"key\":\"proxy_settings\",\"value\":\"{\\\"channel_shutdown_delay\\\":8}\"}," +
+                "{\"id\":2,\"key\":\"default_stream_profile\",\"value\":\"2\"}," +
+                "{\"id\":3,\"key\":\"default-user-agent\",\"value\":1}]";
+
+            string requestedPath = null;
+            var handler = new MockHandler(request =>
+            {
+                if (request.RequestUri.AbsolutePath.Contains("/api/accounts/token/"))
+                {
+                    var json = JsonSerializer.Serialize(new { access = "tok", refresh = "ref" });
+                    return new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new StringContent(json, Encoding.UTF8, "application/json")
+                    };
+                }
+                requestedPath = request.RequestUri.AbsolutePath;
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(settingsJson, Encoding.UTF8, "application/json")
+                };
+            });
+
+            var client = CreateClient(handler);
+            client.Configure("admin", "pass");
+            var id = await client.GetDefaultStreamProfileIdAsync("http://localhost:8080", CancellationToken.None);
+
+            Assert.Equal(2, id);
+            Assert.Equal("/api/core/settings/", requestedPath);
+        }
+
+        [Fact]
+        public async Task GetChannelData_MapsStreamProfileIdUnderBothKeys()
+        {
+            // Same dual-key discipline as every other map here: the Xtream stream_id covers
+            // Config A and Dispatcharr's own channel ID covers Config B. effective_stream_
+            // profile_id wins over stream_profile_id, and a channel with neither is written
+            // as 0, the sentinel for "use the server default profile".
+            var channelsJson = "[" +
+                "{\"id\":11,\"uuid\":\"u-1\",\"name\":\"A\",\"stream_profile_id\":5," +
+                "\"effective_stream_profile_id\":7,\"streams\":[{\"id\":1,\"stream_id\":69307}]}," +
+                "{\"id\":12,\"uuid\":\"u-2\",\"name\":\"B\",\"stream_profile_id\":5," +
+                "\"streams\":[{\"id\":2,\"stream_id\":69308}]}," +
+                "{\"id\":13,\"uuid\":\"u-3\",\"name\":\"C\"," +
+                "\"streams\":[{\"id\":3,\"stream_id\":69309}]}]";
+
+            var (_, _, _, _, _, _, profileIds) = await RunGetChannelData(channelsJson);
+
+            // Effective value wins where present, both keyed by Xtream stream_id and channel ID.
+            Assert.Equal(7, profileIds[69307]);
+            Assert.Equal(7, profileIds[11]);
+            // Older serializers only send stream_profile_id.
+            Assert.Equal(5, profileIds[69308]);
+            Assert.Equal(5, profileIds[12]);
+            // No profile of its own: sentinel 0, resolved against the server default later.
+            Assert.Equal(0, profileIds[69309]);
+            Assert.Equal(0, profileIds[13]);
+        }
+
         private static async Task<(
             System.Collections.Generic.Dictionary<int, string> UuidMap,
             System.Collections.Generic.Dictionary<int, StreamStatsInfo> StatsMap,
             System.Collections.Generic.Dictionary<int, string> TvgIdMap,
             System.Collections.Generic.Dictionary<int, string> StationIdMap,
             System.Collections.Generic.HashSet<int> AllowedStreamIds,
-            System.Collections.Generic.Dictionary<int, double> ChannelNumberMap)>
+            System.Collections.Generic.Dictionary<int, double> ChannelNumberMap,
+            System.Collections.Generic.Dictionary<int, int> StreamProfileIdMap)>
             RunGetChannelData(string channelsJson)
         {
             var handler = new MockHandler(request =>

--- a/Emby.Xtream.Plugin.Tests/DispatcharrClientTests.cs
+++ b/Emby.Xtream.Plugin.Tests/DispatcharrClientTests.cs
@@ -961,6 +961,60 @@ namespace Emby.Xtream.Plugin.Tests
         }
 
         [Fact]
+        public async Task GetDefaultStreamProfileId_ReadsTheGroupedStreamSettingsShape()
+        {
+            // Live shape on Dispatcharr 0.29: settings are grouped into blobs and the profile
+            // sits inside the stream_settings row rather than in a row of its own.
+            var settingsJson = "[" +
+                "{\"id\":1,\"key\":\"proxy_settings\",\"value\":{\"channel_shutdown_delay\":1}}," +
+                "{\"id\":2,\"key\":\"stream_settings\",\"value\":{\"default_stream_profile\":3," +
+                "\"default_user_agent\":1,\"m3u_hash_key\":\"url\"}}]";
+
+            Assert.Equal(3, await RunGetDefaultStreamProfileId(settingsJson));
+        }
+
+        [Fact]
+        public async Task GetDefaultStreamProfileId_ReadsAGroupedBlobSentAsAString()
+        {
+            // Same grouping, but the blob arrives JSON-encoded inside a string.
+            var settingsJson = "[{\"id\":2,\"key\":\"stream_settings\"," +
+                "\"value\":\"{\\\"default_stream_profile\\\": 4}\"}]";
+
+            Assert.Equal(4, await RunGetDefaultStreamProfileId(settingsJson));
+        }
+
+        [Fact]
+        public async Task GetDefaultStreamProfileId_ReturnsNullWhenTheSettingIsAbsent()
+        {
+            var settingsJson = "[{\"id\":1,\"key\":\"system_settings\",\"value\":{\"time_zone\":\"Europe/Amsterdam\"}}]";
+
+            Assert.Null(await RunGetDefaultStreamProfileId(settingsJson));
+        }
+
+        private static async Task<int?> RunGetDefaultStreamProfileId(string settingsJson)
+        {
+            var handler = new MockHandler(request =>
+            {
+                if (request.RequestUri.AbsolutePath.Contains("/api/accounts/token/"))
+                {
+                    var json = JsonSerializer.Serialize(new { access = "tok", refresh = "ref" });
+                    return new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new StringContent(json, Encoding.UTF8, "application/json")
+                    };
+                }
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(settingsJson, Encoding.UTF8, "application/json")
+                };
+            });
+
+            var client = CreateClient(handler);
+            client.Configure("admin", "pass");
+            return await client.GetDefaultStreamProfileIdAsync("http://localhost:8080", CancellationToken.None);
+        }
+
+        [Fact]
         public async Task GetChannelData_MapsStreamProfileIdUnderBothKeys()
         {
             // Same dual-key discipline as every other map here: the Xtream stream_id covers
@@ -973,7 +1027,9 @@ namespace Emby.Xtream.Plugin.Tests
                 "{\"id\":12,\"uuid\":\"u-2\",\"name\":\"B\",\"stream_profile_id\":5," +
                 "\"streams\":[{\"id\":2,\"stream_id\":69308}]}," +
                 "{\"id\":13,\"uuid\":\"u-3\",\"name\":\"C\"," +
-                "\"streams\":[{\"id\":3,\"stream_id\":69309}]}]";
+                "\"streams\":[{\"id\":3,\"stream_id\":69309}]}," +
+                "{\"id\":14,\"uuid\":\"u-4\",\"name\":\"D\",\"stream_profile_id\":5," +
+                "\"streams\":[{\"id\":4,\"stream_id\":69310,\"stream_profile_id\":9}]}]";
 
             var (_, _, _, _, _, _, profileIds) = await RunGetChannelData(channelsJson);
 
@@ -986,6 +1042,10 @@ namespace Emby.Xtream.Plugin.Tests
             // No profile of its own: sentinel 0, resolved against the server default later.
             Assert.Equal(0, profileIds[69309]);
             Assert.Equal(0, profileIds[13]);
+            // A stream's own profile wins over the channel's, which is the order Dispatcharr
+            // resolves them in. The channel key keeps the channel's own value.
+            Assert.Equal(9, profileIds[69310]);
+            Assert.Equal(5, profileIds[14]);
         }
 
         private static async Task<(

--- a/Emby.Xtream.Plugin.Tests/XtreamTunerHostTests.cs
+++ b/Emby.Xtream.Plugin.Tests/XtreamTunerHostTests.cs
@@ -205,7 +205,7 @@ namespace Emby.Xtream.Plugin.Tests
                 AudioCodec = "aac",
                 Resolution = "1920x1080",
                 SourceFps = 50,
-                Bitrate = 4.5,         // 4.5 Mbps
+                Bitrate = 4500,        // 4.5 Mbps (Dispatcharr reports kbps; factory multiplies by 1000)
                 AudioBitrate = 128,    // 128 kbps
                 AudioChannels = "stereo",
                 SampleRate = 48000,
@@ -250,12 +250,12 @@ namespace Emby.Xtream.Plugin.Tests
             Assert.Equal(1920, video.Width);
             Assert.Equal(1080, video.Height);
             Assert.Equal(50f, video.RealFrameRate);
-            // Factory converts stats.Bitrate (in Mbps from Dispatcharr's ffmpeg_output_bitrate
-            // key) to bps via * 1000. For 4.5 Mbps that yields 4500 bps — the same convention
-            // applied to every other consumer of stats.Bitrate in CreateMediaSourceInfo. The
-            // test pins that conversion so a future scope-creep fix that switches to *1_000_000
-            // is forced to update the assertion alongside.
-            Assert.Equal(4500, video.BitRate);
+            // Factory converts stats.Bitrate (in kbps from Dispatcharr's ffmpeg_output_bitrate
+            // field, per StreamStatsInfo.cs:19) to bps via * 1000 at XtreamTunerHost.cs:1563.
+            // For a 4500 kbps stream that yields 4_500_000 bps. The test pins that conversion
+            // so a future scope-creep fix that switches to * 1_000_000 is forced to update the
+            // assertion alongside.
+            Assert.Equal(4_500_000, video.BitRate);
             Assert.Equal("Main", video.Profile);
             Assert.Equal(41.0, video.Level);
         }

--- a/Emby.Xtream.Plugin.Tests/XtreamTunerHostTests.cs
+++ b/Emby.Xtream.Plugin.Tests/XtreamTunerHostTests.cs
@@ -92,6 +92,21 @@ namespace Emby.Xtream.Plugin.Tests
             Assert.Equal(expected, StreamProfileCodec.Parse(command, parameters));
         }
 
+        [Theory]
+        // Codex review on PR #67: profiles are written by hand in Dispatcharr's UI, so the
+        // encoder turns up quoted, and the flag turns up joined to its value with "=".
+        // Both used to read as "no answer", which left the transcoding channel broken.
+        [InlineData("-i {streamUrl} -c:v \"h264_nvenc\" -f mpegts pipe:1", "h264")]
+        [InlineData("-i {streamUrl} -c:v 'hevc_nvenc' -f mpegts pipe:1", "hevc")]
+        [InlineData("-i {streamUrl} -c:v=h264_nvenc -f mpegts pipe:1", "h264")]
+        [InlineData("-i {streamUrl} -vcodec=libx265 -f mpegts pipe:1", "hevc")]
+        [InlineData("-i {streamUrl} -c:v=\"h264_qsv\" -f mpegts pipe:1", "h264")]
+        [InlineData("-i {streamUrl} -c:v=copy -f mpegts pipe:1", null)]
+        public void StreamProfileCodec_ParsesQuotedAndEqualsForms(string parameters, string expected)
+        {
+            Assert.Equal(expected, StreamProfileCodec.Parse("ffmpeg", parameters));
+        }
+
         [Fact]
         public void StreamProfileCodec_LastCodecFlagWins()
         {

--- a/Emby.Xtream.Plugin.Tests/XtreamTunerHostTests.cs
+++ b/Emby.Xtream.Plugin.Tests/XtreamTunerHostTests.cs
@@ -4,54 +4,44 @@ using Xunit;
 namespace Emby.Xtream.Plugin.Tests
 {
     /// <summary>
-    /// Regression tests for issue #66 — Dispatcharr's <c>stream_stats.video_codec</c> field
-    /// is the codec Dispatcharr *ingested* from the source, not the codec it *emits*.
-    /// On a channel whose Dispatcharr stream profile transcodes video (e.g. HEVC source
-    /// → H.264 output) the plugin was declaring the source codec and setting
-    /// <c>SupportsProbing=false</c>, which forced Emby to apply the wrong decoder and
-    /// the channel failed to play.
+    /// Regression tests for issue [#66](https://github.com/firestaerter3/emby-xtream/issues/66)
+    /// — Dispatcharr's <c>stream_stats.video_codec</c> field is the codec Dispatcharr
+    /// *ingested* from the source, not the codec it *emits*. On a channel whose Dispatcharr
+    /// stream profile transcodes video (e.g. HEVC source → H.264 output) the plugin was
+    /// declaring the source codec on the MediaStream and forcing the wrong decoder, so the
+    /// channel failed to play.
     ///
     /// The fix: <see cref="PluginConfiguration.DispatcharrUseStatsCodec"/> (default true).
-    /// When false, the plugin ignores the VideoCodec from stream_stats, collapses
-    /// <c>hasStats</c> to audio-only-or-absent, and lets Emby probe the proxy URL to
-    /// discover the real output codec. The placeholder for full integration tests
-    /// remains — this file exercises the static decision helper, which is enough to
-    /// pin the bug-fix logic without touching the static <c>_streamStats</c> cache.
+    /// When false, the plugin ignores <c>VideoCodec</c> from stream_stats and leaves the
+    /// codec field unset on the video MediaStream — no probe, no codec hint. AGENTS.md
+    /// forbids re-enabling probing on Dispatcharr proxy URLs regardless of stats, so the
+    /// escape lives in the declaration path, not in relaxing the no-probe rule.
+    ///
+    /// Audio-only detection, resolution, FPS, bitrate, profile, level, and audio codec
+    /// stay honoured regardless of <c>DispatcharrUseStatsCodec</c> — only the video
+    /// codec field and its display title are gated.
     /// </summary>
     public class XtreamTunerHostTests
     {
         [Theory]
-        // (disableProbing, hasStats, expected) — pins the helper's truth table. The helper
-        // is intentionally just `disableProbing || hasStats`. The decision lives in the
-        // helper, but the call site wires `effectiveDisableProbing = disableProbing && useStatsCodec`
-        // (issue #66) so probing is allowed when the user has opted out of stats codec.
-        [InlineData(true, true, true)]
-        // Audio-only path with stats (hasStats=true via isAudioOnly, even with no video).
-        // Probing still suppressed — there's no video stream to discover.
-        [InlineData(true, false, true)]
-        // Non-Dispatcharr path (direct Xtream URL) with stats: legacy behavior suppresses
-        // probing. Stats are accurate because there's no proxy transcoding.
-        [InlineData(false, true, true)]
-        // No stats, no Dispatcharr flag: probe, fall back to ffprobe.
-        [InlineData(false, false, false)]
+        // (disableProbing, hasStats, expected) — pins the helper's truth table.
+        // AGENTS.md makes the no-probe rule absolute for Dispatcharr proxy URLs:
+        // probing is always suppressed when either the dispatcharr-side flag is set
+        // OR stats are present. The fix for issue #66 does NOT relax this gate.
+        [InlineData(true, true, true)]    // Dispatcharr + stats: suppress (unchanged)
+        [InlineData(true, false, true)]   // Dispatcharr + no stats: suppress (unchanged)
+        [InlineData(false, true, true)]   // Direct Xtream + stats: suppress (unchanged)
+        [InlineData(false, false, false)] // Direct Xtream + no stats: probe (unchanged)
         public void ShouldSuppressProbing_MatchesLegacyTruthTable(bool disableProbing, bool hasStats, bool expected)
         {
-            // The helper is intentionally just `disableProbing || hasStats`. This test pins
-            // that identity — if anyone tries to "simplify" it later, the truth-table will
-            // catch the change and they'll need to update both the test and the ADR.
             Assert.Equal(expected, XtreamTunerHost.ShouldSuppressProbing(disableProbing, hasStats));
         }
 
         [Fact]
         public void ShouldSuppressProbing_DisableProbingFlagAloneSuppresses()
         {
-            // The Dispatcharr path always calls CreateMediaSourceInfo with
-            // disableProbing=true. The fix in CreateMediaSourceInfo (#66) is to AND the
-            // disableProbing flag with useStatsCodec BEFORE calling this helper, so the
-            // helper itself still receives the raw disableProbing/hasStats pair. This
-            // test documents that contract: when disableProbing is true, probing is
-            // suppressed regardless of hasStats. The escape route for #66 lives in the
-            // caller, not the helper.
+            // Dispatcharr path always calls CreateMediaSourceInfo with disableProbing=true.
+            // Probing stays off regardless of stats — AGENTS.md forbids relaxing this.
             Assert.True(XtreamTunerHost.ShouldSuppressProbing(
                 disableProbing: true,
                 hasStats: false));
@@ -70,43 +60,79 @@ namespace Emby.Xtream.Plugin.Tests
         }
 
         [Theory]
-        // Issue #66 escape: the dispatcharr-side disable flag is dropped when the user
-        // has opted out of the stats codec. The helper pins the wiring logic so the
-        // bug can't regress without both the helper and the test changing.
-        [InlineData(true, false, false)]   // Dispatcharr + user opted out → probing allowed
-        [InlineData(true, true, true)]     // Dispatcharr + default (legacy) → suppress
-        [InlineData(false, false, false)]  // Direct Xtream + user opted out → probing allowed
-        [InlineData(false, true, false)]   // Direct Xtream + default → probing allowed
-        public void ShouldDisableProbing_Issue66DropsFlagWhenUserOptsOut(
-            bool disableProbing, bool useStatsCodec, bool expected)
+        // Issue #66: when the user has opted out of stats codec, the video codec on the
+        // MediaStream MUST be left unset. Declaring the input codec on a transcoded
+        // Dispatcharr stream profile (HEVC source → H.264 output) forces Emby to apply the
+        // wrong decoder. The codec declaration is gated by hasVideoCodecFromStats (which is
+        // itself gated by useStatsCodec upstream), so passing false here mirrors the opt-out.
+        [InlineData(true, false, false)]  // Stats have codec but user opted out → do not declare (issue #66)
+        [InlineData(true, true, true)]    // Stats have codec + default → declare (legacy pass-through)
+        [InlineData(false, true, false)]  // Stats missing codec → do not declare
+        [InlineData(false, false, false)] // Stats missing codec + opt-out → do not declare
+        public void ShouldDeclareVideoCodec_Issue66OmitsCodecOnOptOut(
+            bool hasVideoCodecFromStats, bool useStatsCodec, bool expected)
         {
-            Assert.Equal(expected, XtreamTunerHost.ShouldDisableProbing(disableProbing, useStatsCodec));
+            Assert.Equal(expected, XtreamTunerHost.ShouldDeclareVideoCodec(hasVideoCodecFromStats, useStatsCodec));
         }
 
         [Fact]
-        public void Issue66_EndToEnd_DispatcharrWithStatsUserOptsOutOfCodec_ProbingRuns()
+        public void ShouldDeclareVideoCodec_OptOutDoesNotAffectAudioOnlyChannels()
+        {
+            // Audio-only channels have stats.AudioCodec but no VideoCodec. hasVideoCodecFromStats
+            // is false regardless of useStatsCodec, so the helper returns false in both cases —
+            // which is correct: an audio-only channel has no video codec to declare or omit.
+            Assert.False(XtreamTunerHost.ShouldDeclareVideoCodec(false, true));
+            Assert.False(XtreamTunerHost.ShouldDeclareVideoCodec(false, false));
+        }
+
+        [Theory]
+        // BuildVideoDisplayTitle covers the four shapes the codec gate produces:
+        //   - codec trusted: "1080p H264"
+        //   - codec omitted (issue #66 opt-out): "1080p"
+        //   - codec trusted but no resolution: "H264"
+        //   - codec omitted and no resolution: null (caller handles null DisplayTitle)
+        [InlineData(1080, "h264", "1080p H264")]   // trusted codec + resolution
+        [InlineData(1080, null, "1080p")]          // issue #66 opt-out + resolution (no codec)
+        [InlineData(0, "h264", "H264")]            // trusted codec, no resolution
+        [InlineData(0, null, null)]                // opt-out, no resolution
+        [InlineData(720, "hevc", "720p HEVC")]     // pass-through HEVC
+        public void BuildVideoDisplayTitle_CoversAllShapes(int height, string codec, string expected)
+        {
+            Assert.Equal(expected, XtreamTunerHost.BuildVideoDisplayTitle(height, codec));
+        }
+
+        [Fact]
+        public void Issue66_EndToEnd_DispatcharrUserOptsOutOfCodec_ProbingStaysOffAndCodecOmitted()
         {
             // Hand-walk through the call-site logic with the reporter's exact bug inputs:
             //   - dispatcharr path (disableProbing = true)
-            //   - stats present: VideoCodec = "hevc", AudioCodec = "aac" (Dispatcharr ingested HEVC)
+            //   - stats present: VideoCodec = "hevc", AudioCodec = "aac" (Dispatcharr ingested HEVC,
+            //     transcode profile outputs H.264)
             //   - user has set DispatcharrUseStatsCodec = false (opt out)
-            // Expected: probing is allowed, so Emby probes the proxy URL and discovers
-            // the real output codec (H.264 in the reporter's setup).
+            // Expected (post-fix):
+            //   - probing is suppressed (AGENTS.md: Dispatcharr proxy URLs never probed)
+            //   - video codec on the MediaStream is left unset (the escape route for #66)
+            //   - audio codec, resolution, and bitrate still flow from stats
             bool disableProbing = true;      // XtreamTunerHost passes this when isDispatcharr=true
             bool useStatsCodec = false;      // DispatcharrUseStatsCodec = false
 
-            // Mimic CreateMediaSourceInfo's hasStats derivation:
-            // hasVideoCodecFromStats = VideoCodec != null && useStatsCodec
-            //                       = true       && false        = false
-            // isAudioOnly = VideoCodec == null && AudioCodec != "" (NOT this case — VideoCodec set)
+            // hasVideoCodecFromStats = stats.VideoCodec != null && useStatsCodec = true && false = false
+            // isAudioOnly = VideoCodec == null && AudioCodec != "" → false (VideoCodec = "hevc")
             // hasStats = false || false = false
-            bool hasStats = false;
+            bool hasVideoCodecFromStats = false;
+            bool isAudioOnly = false;
+            bool hasStats = hasVideoCodecFromStats || isAudioOnly;
 
-            bool effective = XtreamTunerHost.ShouldDisableProbing(disableProbing, useStatsCodec);
-            bool suppress = XtreamTunerHost.ShouldSuppressProbing(effective, hasStats);
+            // Probing gate (unchanged from legacy):
+            bool suppressProbing = XtreamTunerHost.ShouldSuppressProbing(disableProbing, hasStats);
+            Assert.True(suppressProbing); // AGENTS.md: Dispatcharr proxy URLs never probed
 
-            Assert.False(effective);
-            Assert.False(suppress);
+            // Codec declaration gate (new helper for issue #66):
+            bool declareVideoCodec = XtreamTunerHost.ShouldDeclareVideoCodec(hasVideoCodecFromStats, useStatsCodec);
+            Assert.False(declareVideoCodec); // issue #66: input codec must not be declared on opt-out
+
+            // Display title falls back to height-only ("1080p") instead of claiming a codec:
+            Assert.Equal("1080p", XtreamTunerHost.BuildVideoDisplayTitle(1080, null));
         }
 
         // -------------------------------------------------------------------------

--- a/Emby.Xtream.Plugin.Tests/XtreamTunerHostTests.cs
+++ b/Emby.Xtream.Plugin.Tests/XtreamTunerHostTests.cs
@@ -112,16 +112,17 @@ namespace Emby.Xtream.Plugin.Tests
             // Expected (post-fix):
             //   - probing is suppressed (AGENTS.md: Dispatcharr proxy URLs never probed)
             //   - video codec on the MediaStream is left unset (the escape route for #66)
-            //   - audio codec, resolution, and bitrate still flow from stats
+            //   - audio codec, resolution, and bitrate still flow from stats (the opt-out
+            //     is ONLY about the video codec, not about all stats — see issue #66 follow-up
+            //     CodeRabbit review on PR #67 head 3c6d056)
             bool disableProbing = true;      // XtreamTunerHost passes this when isDispatcharr=true
             bool useStatsCodec = false;      // DispatcharrUseStatsCodec = false
+            bool statsPresent = true;        // Dispatcharr returned stats for this channel
 
             // hasVideoCodecFromStats = stats.VideoCodec != null && useStatsCodec = true && false = false
-            // isAudioOnly = VideoCodec == null && AudioCodec != "" → false (VideoCodec = "hevc")
-            // hasStats = false || false = false
+            // hasStats = stats != null (true) — opt-out must NOT drop resolution/audio/FPS
             bool hasVideoCodecFromStats = false;
-            bool isAudioOnly = false;
-            bool hasStats = hasVideoCodecFromStats || isAudioOnly;
+            bool hasStats = statsPresent;
 
             // Probing gate (unchanged from legacy):
             bool suppressProbing = XtreamTunerHost.ShouldSuppressProbing(disableProbing, hasStats);
@@ -133,6 +134,39 @@ namespace Emby.Xtream.Plugin.Tests
 
             // Display title falls back to height-only ("1080p") instead of claiming a codec:
             Assert.Equal("1080p", XtreamTunerHost.BuildVideoDisplayTitle(1080, null));
+        }
+
+        [Fact]
+        public void Issue66_HasStats_TracksStatsPresenceNotVideoCodec_Gate()
+        {
+            // CodeRabbit review on PR #67 head 3c6d056 caught that the original fix's
+            //   bool hasStats = hasVideoCodecFromStats || isAudioOnly;
+            // drops ALL stats (audio codec, resolution, FPS, bitrate, profile, level) when
+            // a video channel has DispatcharrUseStatsCodec=false. The opt-out is meant to
+            // suppress only the (misleading) video codec, not every other stat the
+            // Dispatcharr stats endpoint exposes.
+            //
+            // The fix: gate hasStats on stats presence, and let ShouldDeclareVideoCodec
+            // handle the codec-suppression case independently. The corrected helper is
+            // XtreamTunerHost.HasStats(stats, isAudioOnly).
+            //
+            // Truth table this test pins:
+            //   stats != null | isAudioOnly | hasStats
+            //   true          | false       | true   (video channel, legacy pass-through)
+            //   true          | true        | true   (audio-only channel)
+            //   true          | false       | true   (video channel, useStatsCodec=false)
+            //   false         | false       | false  (no stats at all)
+
+            // Row: video channel, opt-out (issue #66). Old gate returned false; new gate
+            // returns true.
+            Assert.True(XtreamTunerHost.HasStats(statsPresent: true, isAudioOnly: false));
+
+            // Row: audio-only channel. Must keep hasStats=true.
+            Assert.True(XtreamTunerHost.HasStats(statsPresent: true, isAudioOnly: true));
+
+            // Row: no stats at all (Dispatcharr 404 or cache miss).
+            Assert.False(XtreamTunerHost.HasStats(statsPresent: false, isAudioOnly: false));
+            Assert.False(XtreamTunerHost.HasStats(statsPresent: false, isAudioOnly: true));
         }
 
         // -------------------------------------------------------------------------

--- a/Emby.Xtream.Plugin.Tests/XtreamTunerHostTests.cs
+++ b/Emby.Xtream.Plugin.Tests/XtreamTunerHostTests.cs
@@ -1,5 +1,14 @@
+using Emby.Xtream.Plugin.Client.Models;
 using Emby.Xtream.Plugin.Service;
+using MediaBrowser.Model.Entities;
+using MediaBrowser.Model.MediaInfo;
 using Xunit;
+
+// SupportsProbing and AnalyzeDurationMs are obsolete on MediaSourceInfo but still
+// functional — they are read by Emby's pipeline even when flagged obsolete. The
+// main project silences CS0612 globally; mirror that here so the test can assert
+// on these properties without noise.
+#pragma warning disable CS0612
 
 namespace Emby.Xtream.Plugin.Tests
 {
@@ -167,6 +176,88 @@ namespace Emby.Xtream.Plugin.Tests
             // Row: no stats at all (Dispatcharr 404 or cache miss).
             Assert.False(XtreamTunerHost.HasStats(statsPresent: false, isAudioOnly: false));
             Assert.False(XtreamTunerHost.HasStats(statsPresent: false, isAudioOnly: true));
+        }
+
+        [Fact]
+        public void CreateMediaSourceInfo_DispatcharrOptOut_OmitsVideoCodecRetainsAudioResolutionBitrate()
+        {
+            // CodeRabbit review on PR #67 head aa76f6d noted the existing suite covered the
+            // static helpers but not the factory. This test constructs the exact reporter
+            // scenario end-to-end: Dispatcharr path, HEVC source / H.264 output via a
+            // transcoding stream profile, user opted out via DispatcharrUseStatsCodec=false.
+            //
+            // Expected post-fix output:
+            //   - SupportsProbing = false (AGENTS.md: Dispatcharr proxy URLs never probed)
+            //   - AnalyzeDurationMs = 0 (same gate)
+            //   - video MediaStream.Codec = null (the escape route for #66)
+            //   - video MediaStream.DisplayTitle = "1080p" (no codec appended)
+            //   - audio MediaStream.Codec = "aac" (audio stays honoured regardless of opt-out)
+            //   - video MediaStream.Width/Height retained (resolution stays honoured)
+            //   - video MediaStream.BitRate retained (bitrate stays honoured)
+            //
+            // The hand-walk version above (Issue66_EndToEnd_*) covers the helpers; this
+            // version pins the assembled MediaSourceInfo so future refactors of the factory
+            // can't drift from the documented contract without breaking a test.
+
+            var stats = new StreamStatsInfo
+            {
+                VideoCodec = "hevc",  // Dispatcharr ingested HEVC; profile transcodes to H.264
+                AudioCodec = "aac",
+                Resolution = "1920x1080",
+                SourceFps = 50,
+                Bitrate = 4.5,         // 4.5 Mbps
+                AudioBitrate = 128,    // 128 kbps
+                AudioChannels = "stereo",
+                SampleRate = 48000,
+                VideoProfile = "Main",
+                VideoLevel = 41,
+            };
+
+            // Reporter scenario: Dispatcharr proxy URL, user opted out of stats codec.
+            var source = XtreamTunerHost.CreateMediaSourceInfo(
+                streamId: 12345,
+                streamUrl: "http://dispatcharr.local/proxy/ts/stream/abc-uuid",
+                stats: stats,
+                disableProbing: true,        // isDispatcharr=true path
+                forceAudioTranscode: false,
+                userAgent: null,
+                fallbackBitrateMbps: 0,
+                declareDvbSubtitles: false,
+                useStatsCodec: false);       // DispatcharrUseStatsCodec = false
+
+            // Probing stays off — AGENTS.md is absolute on this for Dispatcharr.
+            Assert.False(source.SupportsProbing);
+            Assert.Equal(0, source.AnalyzeDurationMs);
+
+            // Locate the video and audio streams in the factory output.
+            var video = Assert.Single(source.MediaStreams, s => s.Type == MediaStreamType.Video);
+            var audio = Assert.Single(source.MediaStreams, s => s.Type == MediaStreamType.Audio);
+
+            // The escape route: codec MUST be omitted on opt-out.
+            Assert.Null(video.Codec);
+            // Display title falls back to height only — no codec to append.
+            Assert.Equal("1080p", video.DisplayTitle);
+
+            // Audio codec stays honoured (independent of the video opt-out).
+            Assert.Equal("aac", audio.Codec);
+            Assert.Equal("stereo", audio.ChannelLayout);
+            Assert.Equal(2, audio.Channels);
+            Assert.Equal(48000, audio.SampleRate);
+            // Audio bitrate comes from AudioBitrate (128 kbps) directly.
+            Assert.Equal(128000, audio.BitRate);
+
+            // Resolution and bitrate stay honoured — the opt-out is ONLY about the codec.
+            Assert.Equal(1920, video.Width);
+            Assert.Equal(1080, video.Height);
+            Assert.Equal(50f, video.RealFrameRate);
+            // Factory converts stats.Bitrate (in Mbps from Dispatcharr's ffmpeg_output_bitrate
+            // key) to bps via * 1000. For 4.5 Mbps that yields 4500 bps — the same convention
+            // applied to every other consumer of stats.Bitrate in CreateMediaSourceInfo. The
+            // test pins that conversion so a future scope-creep fix that switches to *1_000_000
+            // is forced to update the assertion alongside.
+            Assert.Equal(4500, video.BitRate);
+            Assert.Equal("Main", video.Profile);
+            Assert.Equal(41.0, video.Level);
         }
 
         // -------------------------------------------------------------------------

--- a/Emby.Xtream.Plugin.Tests/XtreamTunerHostTests.cs
+++ b/Emby.Xtream.Plugin.Tests/XtreamTunerHostTests.cs
@@ -194,6 +194,10 @@ namespace Emby.Xtream.Plugin.Tests
             //   - audio MediaStream.Codec = "aac" (audio stays honoured regardless of opt-out)
             //   - video MediaStream.Width/Height retained (resolution stays honoured)
             //   - video MediaStream.BitRate retained (bitrate stays honoured)
+            //   - video MediaStream.Profile/Level/BitDepth/RefFrames omitted: these describe
+            //     the ingested codec, so they are no more trustworthy than the codec itself
+            //     once the stream profile transcodes (a level number means something
+            //     different in HEVC than in H.264)
             //
             // The hand-walk version above (Issue66_EndToEnd_*) covers the helpers; this
             // version pins the assembled MediaSourceInfo so future refactors of the factory
@@ -211,6 +215,8 @@ namespace Emby.Xtream.Plugin.Tests
                 SampleRate = 48000,
                 VideoProfile = "Main",
                 VideoLevel = 41,
+                VideoBitDepth = 10,
+                VideoRefFrames = 4,
             };
 
             // Reporter scenario: Dispatcharr proxy URL, user opted out of stats codec.
@@ -256,8 +262,14 @@ namespace Emby.Xtream.Plugin.Tests
             // so a future scope-creep fix that switches to * 1_000_000 is forced to update the
             // assertion alongside.
             Assert.Equal(4_500_000, video.BitRate);
-            Assert.Equal("Main", video.Profile);
-            Assert.Equal(41.0, video.Level);
+
+            // Codec-derived attributes are gated with the codec. Declaring "Main / level 41 /
+            // 10-bit / 4 ref frames" from an HEVC source on an H.264 output is the same bug
+            // class as #66, one field over.
+            Assert.Null(video.Profile);
+            Assert.Null(video.Level);
+            Assert.Null(video.BitDepth);
+            Assert.Null(video.RefFrames);
         }
 
         // -------------------------------------------------------------------------
@@ -313,6 +325,10 @@ namespace Emby.Xtream.Plugin.Tests
                 AudioCodec = "aac",
                 Resolution = "1920x1080",
                 Bitrate = 4500,
+                VideoProfile = "Main",
+                VideoLevel = 41,
+                VideoBitDepth = 10,
+                VideoRefFrames = 4,
             };
 
             var source = XtreamTunerHost.CreateMediaSourceInfo(
@@ -340,6 +356,13 @@ namespace Emby.Xtream.Plugin.Tests
 
             // Audio codec honoured.
             Assert.Equal("aac", audio.Codec);
+
+            // The other side of the codec-derived gate: with the codec trusted, profile,
+            // level, bit depth and reference frames are declared alongside it.
+            Assert.Equal("Main", video.Profile);
+            Assert.Equal(41.0, video.Level);
+            Assert.Equal(10, video.BitDepth);
+            Assert.Equal(4, video.RefFrames);
         }
     }
 }

--- a/Emby.Xtream.Plugin.Tests/XtreamTunerHostTests.cs
+++ b/Emby.Xtream.Plugin.Tests/XtreamTunerHostTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using Emby.Xtream.Plugin.Client.Models;
 using Emby.Xtream.Plugin.Service;
 using MediaBrowser.Model.Entities;
@@ -20,305 +21,262 @@ namespace Emby.Xtream.Plugin.Tests
     /// declaring the source codec on the MediaStream and forcing the wrong decoder, so the
     /// channel failed to play.
     ///
-    /// The fix: <see cref="PluginConfiguration.DispatcharrUseStatsCodec"/> (default true).
-    /// When false, the plugin ignores <c>VideoCodec</c> from stream_stats and leaves the
-    /// codec field unset on the video MediaStream — no probe, no codec hint. AGENTS.md
-    /// forbids re-enabling probing on Dispatcharr proxy URLs regardless of stats, so the
-    /// escape lives in the declaration path, not in relaxing the no-probe rule.
-    ///
-    /// Audio-only detection, resolution, FPS, bitrate, profile, level, and audio codec
-    /// stay honoured regardless of <c>DispatcharrUseStatsCodec</c> — only the video
-    /// codec field and its display title are gated.
+    /// The fix reads the channel's Dispatcharr stream profile, which states what the proxy
+    /// actually emits, and declares that. Probing stays off for Dispatcharr proxy URLs
+    /// (AGENTS.md is absolute on this), and the declared codec is never null: the no-stats
+    /// branch documents that Emby's RecordingRequiresEncoding dereferences the field.
+    /// <see cref="PluginConfiguration.DispatcharrVideoCodecSource"/> can override the
+    /// automatic answer for installs where the profile cannot be read.
     /// </summary>
     public class XtreamTunerHostTests
     {
+        // ---------------------------------------------------------------------
+        // Probing gate — unchanged by the #66 fix, pinned so it stays that way.
+        // ---------------------------------------------------------------------
+
         [Theory]
         // (disableProbing, hasStats, expected) — pins the helper's truth table.
         // AGENTS.md makes the no-probe rule absolute for Dispatcharr proxy URLs:
         // probing is always suppressed when either the dispatcharr-side flag is set
         // OR stats are present. The fix for issue #66 does NOT relax this gate.
-        [InlineData(true, true, true)]    // Dispatcharr + stats: suppress (unchanged)
-        [InlineData(true, false, true)]   // Dispatcharr + no stats: suppress (unchanged)
-        [InlineData(false, true, true)]   // Direct Xtream + stats: suppress (unchanged)
-        [InlineData(false, false, false)] // Direct Xtream + no stats: probe (unchanged)
+        [InlineData(true, true, true)]    // Dispatcharr + stats: suppress
+        [InlineData(true, false, true)]   // Dispatcharr + no stats: suppress
+        [InlineData(false, true, true)]   // Direct Xtream + stats: suppress
+        [InlineData(false, false, false)] // Direct Xtream + no stats: probe
         public void ShouldSuppressProbing_MatchesLegacyTruthTable(bool disableProbing, bool hasStats, bool expected)
         {
             Assert.Equal(expected, XtreamTunerHost.ShouldSuppressProbing(disableProbing, hasStats));
         }
 
         [Fact]
-        public void ShouldSuppressProbing_DisableProbingFlagAloneSuppresses()
+        public void HasStats_TracksStatsPresenceNotVideoCodec()
         {
-            // Dispatcharr path always calls CreateMediaSourceInfo with disableProbing=true.
-            // Probing stays off regardless of stats — AGENTS.md forbids relaxing this.
-            Assert.True(XtreamTunerHost.ShouldSuppressProbing(
-                disableProbing: true,
-                hasStats: false));
+            // CodeRabbit review on PR #67 head 3c6d056 caught that gating hasStats on codec
+            // trust drops every other stat (resolution, FPS, bitrate, audio) for a video
+            // channel whose codec is not being taken from stats. Stats presence and codec
+            // trust are separate questions.
+            Assert.True(XtreamTunerHost.HasStats(statsPresent: true, isAudioOnly: false));
+            Assert.True(XtreamTunerHost.HasStats(statsPresent: true, isAudioOnly: true));
+            Assert.False(XtreamTunerHost.HasStats(statsPresent: false, isAudioOnly: false));
+            Assert.False(XtreamTunerHost.HasStats(statsPresent: false, isAudioOnly: true));
+        }
+
+        // ---------------------------------------------------------------------
+        // Reading the output codec out of a Dispatcharr stream profile.
+        // ---------------------------------------------------------------------
+
+        [Theory]
+        // The reporter's own profile shape: NVENC H.264 output from whatever comes in.
+        [InlineData("ffmpeg", "-i {streamUrl} -c:v h264_nvenc -c:a aac -f mpegts pipe:1", "h264")]
+        [InlineData("ffmpeg", "-i {streamUrl} -c:v libx264 -f mpegts pipe:1", "h264")]
+        [InlineData("ffmpeg", "-i {streamUrl} -c:v libx265 -f mpegts pipe:1", "hevc")]
+        [InlineData("ffmpeg", "-i {streamUrl} -c:v hevc_qsv -f mpegts pipe:1", "hevc")]
+        [InlineData("ffmpeg", "-i {streamUrl} -c:v:0 h264_vaapi -f mpegts pipe:1", "h264")]
+        [InlineData("ffmpeg", "-i {streamUrl} -vcodec libx264 -f mpegts pipe:1", "h264")]
+        [InlineData("ffmpeg", "-i {streamUrl} -codec:v mpeg2video -f mpegts pipe:1", "mpeg2video")]
+        // Pass-through: the ingested codec is also the emitted one, so the profile has no
+        // answer to add and the caller falls back to stream_stats.
+        [InlineData("ffmpeg", "-i {streamUrl} -c:v copy -c:a aac -f mpegts pipe:1", null)]
+        [InlineData("ffmpeg", "-i {streamUrl} -c copy -f mpegts pipe:1", null)]
+        // An encoder we don't recognise must read as "no answer". Handing Emby "av1_nvenc"
+        // as a codec name is worse than handing it nothing, because Emby will try to use it.
+        [InlineData("ffmpeg", "-i {streamUrl} -c:v av1_nvenc -f mpegts pipe:1", null)]
+        // Non-ffmpeg profiles (the built-in redirect/proxy profiles, streamlink, scripts)
+        // never re-encode.
+        [InlineData("streamlink", "{streamUrl} best -O", null)]
+        [InlineData("redirect", "{streamUrl}", null)]
+        [InlineData("ffmpeg", "", null)]
+        [InlineData("ffmpeg", null, null)]
+        public void StreamProfileCodec_ParsesOutputCodec(string command, string parameters, string expected)
+        {
+            Assert.Equal(expected, StreamProfileCodec.Parse(command, parameters));
         }
 
         [Fact]
-        public void ShouldSuppressProbing_HasStatsAloneSuppresses()
+        public void StreamProfileCodec_LastCodecFlagWins()
         {
-            // Audio-only path: stats have AudioCodec but no VideoCodec. hasStats is true
-            // (via the audio-only branch). Even with disableProbing false, probing is
-            // suppressed — there's no video to probe for and the helper shouldn't second-
-            // guess the caller's intent.
-            Assert.True(XtreamTunerHost.ShouldSuppressProbing(
-                disableProbing: false,
-                hasStats: true));
-        }
-
-        [Theory]
-        // Issue #66: when the user has opted out of stats codec, the video codec on the
-        // MediaStream MUST be left unset. Declaring the input codec on a transcoded
-        // Dispatcharr stream profile (HEVC source → H.264 output) forces Emby to apply the
-        // wrong decoder. The codec declaration is gated by hasVideoCodecFromStats (which is
-        // itself gated by useStatsCodec upstream), so passing false here mirrors the opt-out.
-        [InlineData(true, false, false)]  // Stats have codec but user opted out → do not declare (issue #66)
-        [InlineData(true, true, true)]    // Stats have codec + default → declare (legacy pass-through)
-        [InlineData(false, true, false)]  // Stats missing codec → do not declare
-        [InlineData(false, false, false)] // Stats missing codec + opt-out → do not declare
-        public void ShouldDeclareVideoCodec_Issue66OmitsCodecOnOptOut(
-            bool hasVideoCodecFromStats, bool useStatsCodec, bool expected)
-        {
-            Assert.Equal(expected, XtreamTunerHost.ShouldDeclareVideoCodec(hasVideoCodecFromStats, useStatsCodec));
+            // ffmpeg applies the last option for a given stream, so a hand-tuned profile that
+            // sets the codec twice must resolve to the later one, in both orders.
+            Assert.Equal("h264", StreamProfileCodec.Parse(
+                "ffmpeg", "-i {streamUrl} -c:v copy -c:v h264_nvenc -f mpegts pipe:1"));
+            Assert.Null(StreamProfileCodec.Parse(
+                "ffmpeg", "-i {streamUrl} -c:v h264_nvenc -c:v copy -f mpegts pipe:1"));
         }
 
         [Fact]
-        public void ShouldDeclareVideoCodec_OptOutDoesNotAffectAudioOnlyChannels()
+        public void StreamProfileCodec_BuildCodecMap_ResolvesOwnProfileAndServerDefault()
         {
-            // Audio-only channels have stats.AudioCodec but no VideoCodec. hasVideoCodecFromStats
-            // is false regardless of useStatsCodec, so the helper returns false in both cases —
-            // which is correct: an audio-only channel has no video codec to declare or omit.
-            Assert.False(XtreamTunerHost.ShouldDeclareVideoCodec(false, true));
-            Assert.False(XtreamTunerHost.ShouldDeclareVideoCodec(false, false));
+            var profiles = new List<DispatcharrStreamProfile>
+            {
+                new DispatcharrStreamProfile { Id = 1, Name = "Proxy", Command = "ffmpeg", Parameters = "-i {streamUrl} -c copy -f mpegts pipe:1" },
+                new DispatcharrStreamProfile { Id = 2, Name = "NVENC H.264", Command = "ffmpeg", Parameters = "-i {streamUrl} -c:v h264_nvenc -c:a aac -f mpegts pipe:1" },
+                new DispatcharrStreamProfile { Id = 3, Name = "NVENC HEVC", Command = "ffmpeg", Parameters = "-i {streamUrl} -c:v hevc_nvenc -f mpegts pipe:1" },
+            };
+
+            var assignments = new Dictionary<int, int>
+            {
+                { 100, 2 },   // channel with its own transcoding profile
+                { 200, 1 },   // channel on the pass-through profile
+                { 300, 0 },   // no profile of its own -> server default (3)
+                { 400, 99 },  // profile that no longer exists
+            };
+
+            var map = StreamProfileCodec.BuildCodecMap(assignments, profiles, defaultProfileId: 3);
+
+            Assert.Equal("h264", map[100]);
+            // Pass-through profiles contribute nothing: the reported codec is already right.
+            Assert.False(map.ContainsKey(200));
+            Assert.Equal("hevc", map[300]);
+            // An unresolvable profile must leave the stream absent rather than guess.
+            Assert.False(map.ContainsKey(400));
+        }
+
+        [Fact]
+        public void StreamProfileCodec_BuildCodecMap_WithoutServerDefault_LeavesUnassignedStreamsOut()
+        {
+            var profiles = new List<DispatcharrStreamProfile>
+            {
+                new DispatcharrStreamProfile { Id = 2, Command = "ffmpeg", Parameters = "-c:v h264_nvenc" },
+            };
+            var assignments = new Dictionary<int, int> { { 100, 0 } };
+
+            var map = StreamProfileCodec.BuildCodecMap(assignments, profiles, defaultProfileId: null);
+
+            Assert.Empty(map);
+        }
+
+        // ---------------------------------------------------------------------
+        // Which codec gets declared.
+        // ---------------------------------------------------------------------
+
+        [Theory]
+        // (isDispatcharr, codecSource, profileCodec, statsCodec, expected)
+        // Automatic: the profile wins when it has an answer. This is issue #66 — the
+        // reporter's channel ingests HEVC and the profile emits H.264.
+        [InlineData(true, "auto", "h264", "hevc", "h264")]
+        // Automatic with a pass-through profile: nothing from the profile, so the reported
+        // codec stands, which is exactly the behaviour before the fix.
+        [InlineData(true, "auto", null, "hevc", "hevc")]
+        // An empty source string is what a config XML written before this setting existed
+        // deserializes to, and must behave as automatic.
+        [InlineData(true, "", "h264", "hevc", "h264")]
+        [InlineData(true, null, "h264", "hevc", "h264")]
+        // Escape hatch: trust what Dispatcharr reports even when a profile was read.
+        [InlineData(true, "stats", "h264", "hevc", "hevc")]
+        // Manual overrides for installs where the profile endpoint is unreachable.
+        [InlineData(true, "h264", null, "hevc", "h264")]
+        [InlineData(true, "hevc", "h264", "h264", "hevc")]
+        // Direct Xtream URLs carry the provider's own bytes, so the reported codec is right
+        // and the Dispatcharr setting does not apply to them.
+        [InlineData(false, "auto", "h264", "hevc", "hevc")]
+        [InlineData(false, "h264", "h264", "hevc", "hevc")]
+        // Nothing known at all: null, which the factory turns into its H.264 fallback.
+        [InlineData(true, "auto", null, null, null)]
+        public void ResolveVideoCodec_MatchesTruthTable(
+            bool isDispatcharr, string codecSource, string profileCodec, string statsCodec, string expected)
+        {
+            Assert.Equal(expected, XtreamTunerHost.ResolveVideoCodec(
+                isDispatcharr, codecSource, profileCodec, statsCodec));
         }
 
         [Theory]
-        // BuildVideoDisplayTitle covers the four shapes the codec gate produces:
-        //   - codec trusted: "1080p H264"
-        //   - codec omitted (issue #66 opt-out): "1080p"
-        //   - codec trusted but no resolution: "H264"
-        //   - codec omitted and no resolution: null (caller handles null DisplayTitle)
-        [InlineData(1080, "h264", "1080p H264")]   // trusted codec + resolution
-        [InlineData(1080, null, "1080p")]          // issue #66 opt-out + resolution (no codec)
-        [InlineData(0, "h264", "H264")]            // trusted codec, no resolution
-        [InlineData(0, null, null)]                // opt-out, no resolution
-        [InlineData(720, "hevc", "720p HEVC")]     // pass-through HEVC
+        // Profile, level, bit depth and reference frames describe the ingested codec, so they
+        // only survive when that is also the codec being declared.
+        [InlineData("h264", "h264", true)]
+        [InlineData("H264", "h264", true)]   // comparison is case-insensitive
+        [InlineData("h264", "hevc", false)]  // transcoded: source attributes do not apply
+        [InlineData("h264", null, false)]
+        [InlineData(null, "h264", false)]
+        [InlineData("", "h264", false)]
+        public void ShouldDeclareCodecAttributes_OnlyWhenDeclaredCodecIsTheStatsCodec(
+            string declaredCodec, string statsCodec, bool expected)
+        {
+            Assert.Equal(expected, XtreamTunerHost.ShouldDeclareCodecAttributes(declaredCodec, statsCodec));
+        }
+
+        [Theory]
+        [InlineData(1080, "h264", "1080p H264")]
+        [InlineData(720, "hevc", "720p HEVC")]
+        [InlineData(0, "h264", "H264")]      // stats with no parsable resolution
+        [InlineData(1080, null, "1080p")]    // defensive: the stats path never passes null now
+        [InlineData(0, null, null)]
         public void BuildVideoDisplayTitle_CoversAllShapes(int height, string codec, string expected)
         {
             Assert.Equal(expected, XtreamTunerHost.BuildVideoDisplayTitle(height, codec));
         }
 
-        [Fact]
-        public void Issue66_EndToEnd_DispatcharrUserOptsOutOfCodec_ProbingStaysOffAndCodecOmitted()
-        {
-            // Hand-walk through the call-site logic with the reporter's exact bug inputs:
-            //   - dispatcharr path (disableProbing = true)
-            //   - stats present: VideoCodec = "hevc", AudioCodec = "aac" (Dispatcharr ingested HEVC,
-            //     transcode profile outputs H.264)
-            //   - user has set DispatcharrUseStatsCodec = false (opt out)
-            // Expected (post-fix):
-            //   - probing is suppressed (AGENTS.md: Dispatcharr proxy URLs never probed)
-            //   - video codec on the MediaStream is left unset (the escape route for #66)
-            //   - audio codec, resolution, and bitrate still flow from stats (the opt-out
-            //     is ONLY about the video codec, not about all stats — see issue #66 follow-up
-            //     CodeRabbit review on PR #67 head 3c6d056)
-            bool disableProbing = true;      // XtreamTunerHost passes this when isDispatcharr=true
-            bool useStatsCodec = false;      // DispatcharrUseStatsCodec = false
-            bool statsPresent = true;        // Dispatcharr returned stats for this channel
-
-            // hasVideoCodecFromStats = stats.VideoCodec != null && useStatsCodec = true && false = false
-            // hasStats = stats != null (true) — opt-out must NOT drop resolution/audio/FPS
-            bool hasVideoCodecFromStats = false;
-            bool hasStats = statsPresent;
-
-            // Probing gate (unchanged from legacy):
-            bool suppressProbing = XtreamTunerHost.ShouldSuppressProbing(disableProbing, hasStats);
-            Assert.True(suppressProbing); // AGENTS.md: Dispatcharr proxy URLs never probed
-
-            // Codec declaration gate (new helper for issue #66):
-            bool declareVideoCodec = XtreamTunerHost.ShouldDeclareVideoCodec(hasVideoCodecFromStats, useStatsCodec);
-            Assert.False(declareVideoCodec); // issue #66: input codec must not be declared on opt-out
-
-            // Display title falls back to height-only ("1080p") instead of claiming a codec:
-            Assert.Equal("1080p", XtreamTunerHost.BuildVideoDisplayTitle(1080, null));
-        }
+        // ---------------------------------------------------------------------
+        // The assembled MediaSourceInfo.
+        // ---------------------------------------------------------------------
 
         [Fact]
-        public void Issue66_HasStats_TracksStatsPresenceNotVideoCodec_Gate()
+        public void CreateMediaSourceInfo_TranscodingProfile_DeclaresOutputCodecAndDropsSourceAttributes()
         {
-            // CodeRabbit review on PR #67 head 3c6d056 caught that the original fix's
-            //   bool hasStats = hasVideoCodecFromStats || isAudioOnly;
-            // drops ALL stats (audio codec, resolution, FPS, bitrate, profile, level) when
-            // a video channel has DispatcharrUseStatsCodec=false. The opt-out is meant to
-            // suppress only the (misleading) video codec, not every other stat the
-            // Dispatcharr stats endpoint exposes.
-            //
-            // The fix: gate hasStats on stats presence, and let ShouldDeclareVideoCodec
-            // handle the codec-suppression case independently. The corrected helper is
-            // XtreamTunerHost.HasStats(stats, isAudioOnly).
-            //
-            // Truth table this test pins:
-            //   stats != null | isAudioOnly | hasStats
-            //   true          | false       | true   (video channel, legacy pass-through)
-            //   true          | true        | true   (audio-only channel)
-            //   true          | false       | true   (video channel, useStatsCodec=false)
-            //   false         | false       | false  (no stats at all)
-
-            // Row: video channel, opt-out (issue #66). Old gate returned false; new gate
-            // returns true.
-            Assert.True(XtreamTunerHost.HasStats(statsPresent: true, isAudioOnly: false));
-
-            // Row: audio-only channel. Must keep hasStats=true.
-            Assert.True(XtreamTunerHost.HasStats(statsPresent: true, isAudioOnly: true));
-
-            // Row: no stats at all (Dispatcharr 404 or cache miss).
-            Assert.False(XtreamTunerHost.HasStats(statsPresent: false, isAudioOnly: false));
-            Assert.False(XtreamTunerHost.HasStats(statsPresent: false, isAudioOnly: true));
-        }
-
-        [Fact]
-        public void CreateMediaSourceInfo_DispatcharrOptOut_OmitsVideoCodecRetainsAudioResolutionBitrate()
-        {
-            // CodeRabbit review on PR #67 head aa76f6d noted the existing suite covered the
-            // static helpers but not the factory. This test constructs the exact reporter
-            // scenario end-to-end: Dispatcharr path, HEVC source / H.264 output via a
-            // transcoding stream profile, user opted out via DispatcharrUseStatsCodec=false.
-            //
-            // Expected post-fix output:
-            //   - SupportsProbing = false (AGENTS.md: Dispatcharr proxy URLs never probed)
-            //   - AnalyzeDurationMs = 0 (same gate)
-            //   - video MediaStream.Codec = null (the escape route for #66)
-            //   - video MediaStream.DisplayTitle = "1080p" (no codec appended)
-            //   - audio MediaStream.Codec = "aac" (audio stays honoured regardless of opt-out)
-            //   - video MediaStream.Width/Height retained (resolution stays honoured)
-            //   - video MediaStream.BitRate retained (bitrate stays honoured)
-            //   - video MediaStream.Profile/Level/BitDepth/RefFrames omitted: these describe
-            //     the ingested codec, so they are no more trustworthy than the codec itself
-            //     once the stream profile transcodes (a level number means something
-            //     different in HEVC than in H.264)
-            //
-            // The hand-walk version above (Issue66_EndToEnd_*) covers the helpers; this
-            // version pins the assembled MediaSourceInfo so future refactors of the factory
-            // can't drift from the documented contract without breaking a test.
-
+            // The reporter's scenario end to end: Dispatcharr ingested HEVC, the stream profile
+            // emits H.264, and the plugin now declares H.264 because the profile said so.
             var stats = new StreamStatsInfo
             {
-                VideoCodec = "hevc",  // Dispatcharr ingested HEVC; profile transcodes to H.264
+                VideoCodec = "hevc",   // what Dispatcharr ingested
                 AudioCodec = "aac",
                 Resolution = "1920x1080",
                 SourceFps = 50,
-                Bitrate = 4500,        // 4.5 Mbps (Dispatcharr reports kbps; factory multiplies by 1000)
-                AudioBitrate = 128,    // 128 kbps
+                Bitrate = 4500,        // kbps from ffmpeg_output_bitrate
+                AudioBitrate = 128,
                 AudioChannels = "stereo",
                 SampleRate = 48000,
-                VideoProfile = "Main",
+                VideoProfile = "Main", // HEVC Main — meaningless for the H.264 output
                 VideoLevel = 41,
                 VideoBitDepth = 10,
                 VideoRefFrames = 4,
             };
 
-            // Reporter scenario: Dispatcharr proxy URL, user opted out of stats codec.
             var source = XtreamTunerHost.CreateMediaSourceInfo(
                 streamId: 12345,
                 streamUrl: "http://dispatcharr.local/proxy/ts/stream/abc-uuid",
                 stats: stats,
-                disableProbing: true,        // isDispatcharr=true path
+                disableProbing: true,          // isDispatcharr = true
                 forceAudioTranscode: false,
                 userAgent: null,
                 fallbackBitrateMbps: 0,
                 declareDvbSubtitles: false,
-                useStatsCodec: false);       // DispatcharrUseStatsCodec = false
+                declaredVideoCodec: "h264");   // resolved from the stream profile
 
             // Probing stays off — AGENTS.md is absolute on this for Dispatcharr.
             Assert.False(source.SupportsProbing);
             Assert.Equal(0, source.AnalyzeDurationMs);
 
-            // Locate the video and audio streams in the factory output.
             var video = Assert.Single(source.MediaStreams, s => s.Type == MediaStreamType.Video);
             var audio = Assert.Single(source.MediaStreams, s => s.Type == MediaStreamType.Audio);
 
-            // The escape route: codec MUST be omitted on opt-out.
-            Assert.Null(video.Codec);
-            // Display title falls back to height only — no codec to append.
-            Assert.Equal("1080p", video.DisplayTitle);
+            // The fix for #66: what the proxy emits, not what it ingested.
+            Assert.Equal("h264", video.Codec);
+            Assert.Equal("1080p H264", video.DisplayTitle);
 
-            // Audio codec stays honoured (independent of the video opt-out).
+            // Output-side stats stay honoured.
+            Assert.Equal(1920, video.Width);
+            Assert.Equal(1080, video.Height);
+            Assert.Equal(50f, video.RealFrameRate);
+            Assert.Equal(4_500_000, video.BitRate);
             Assert.Equal("aac", audio.Codec);
             Assert.Equal("stereo", audio.ChannelLayout);
             Assert.Equal(2, audio.Channels);
             Assert.Equal(48000, audio.SampleRate);
-            // Audio bitrate comes from AudioBitrate (128 kbps) directly.
             Assert.Equal(128000, audio.BitRate);
 
-            // Resolution and bitrate stay honoured — the opt-out is ONLY about the codec.
-            Assert.Equal(1920, video.Width);
-            Assert.Equal(1080, video.Height);
-            Assert.Equal(50f, video.RealFrameRate);
-            // Factory converts stats.Bitrate (in kbps from Dispatcharr's ffmpeg_output_bitrate
-            // field, per StreamStatsInfo.cs:19) to bps via * 1000 at XtreamTunerHost.cs:1563.
-            // For a 4500 kbps stream that yields 4_500_000 bps. The test pins that conversion
-            // so a future scope-creep fix that switches to * 1_000_000 is forced to update the
-            // assertion alongside.
-            Assert.Equal(4_500_000, video.BitRate);
-
-            // Codec-derived attributes are gated with the codec. Declaring "Main / level 41 /
-            // 10-bit / 4 ref frames" from an HEVC source on an H.264 output is the same bug
-            // class as #66, one field over.
+            // Source-codec attributes are dropped: "Main / level 41 / 10-bit / 4 ref frames"
+            // describes the HEVC input, and declaring it on an H.264 output is the same bug
+            // as #66 one field over.
             Assert.Null(video.Profile);
             Assert.Null(video.Level);
             Assert.Null(video.BitDepth);
             Assert.Null(video.RefFrames);
         }
 
-        // -------------------------------------------------------------------------
-        // Placeholder for deferred full integration tests. See class-level XML doc for
-        // the planned scenarios — they require refactoring the static _streamStats
-        // cache to instance-level before they can run with isolation. This Fact runs
-        // (not skipped) so the suite still tracks the work item.
-        // -------------------------------------------------------------------------
         [Fact]
-        public void Placeholder_StaticStreamStatsCachePreventsIsolation()
+        public void CreateMediaSourceInfo_PassThroughProfile_KeepsReportedCodecAndAttributes()
         {
-            Assert.True(true, "Placeholder: defer full XtreamTunerHost scenarios until _streamStats is instance-level.");
-        }
-
-        [Theory]
-        // CodeRabbit finding on PR #67 head 8c2e46e: when BuildStreamUrl falls back to a
-        // direct Xtream URL, isDispatcharr=false but _streamStats may still hold Dispatcharr
-        // stats for the channel. Passing config.DispatcharrUseStatsCodec raw then strips
-        // the codec hint from the direct fallback. Stats also suppress probing, so the
-        // fallback loses BOTH codec and probe. ShouldUseStatsCodec gates the opt-out to
-        // Dispatcharr sources only.
-        [InlineData(true, true, true)]    // Dispatcharr + default: opt-out not active
-        [InlineData(true, false, false)]  // Dispatcharr + opt-out: skip codec (issue #66)
-        [InlineData(false, true, true)]   // Direct Xtream + default: trust codec
-        [InlineData(false, false, true)]  // Direct Xtream + opt-out: opt-out N/A, trust codec
-        public void ShouldUseStatsCodec_GatesOptOutToDispatcharrOnly(bool isDispatcharr, bool dispatcharrUseStatsCodec, bool expected)
-        {
-            Assert.Equal(expected, XtreamTunerHost.ShouldUseStatsCodec(isDispatcharr, dispatcharrUseStatsCodec));
-        }
-
-        [Fact]
-        public void CreateMediaSourceInfo_DirectXtreamFallback_RetainsCodecDespiteOptOut()
-        {
-            // CodeRabbit finding on PR #67 head 8c2e46e regression: when BuildStreamUrl
-            // returns a direct Xtream URL but Dispatcharr stats are still cached for the
-            // channel, the opt-out must NOT apply — stats already suppress probing, so
-            // stripping the codec hint leaves the direct fallback with neither codec nor
-            // probe. ShouldUseStatsCodec(now isDispatcharr=false, configOptOut=false) = true,
-            // so the caller hands useStatsCodec=true to the factory. This test pins the
-            // factory output for the post-gate direct-fallback case.
-            //
-            // Expected output for direct Xtream fallback:
-            //   - disableProbing = false (isDispatcharr=false path)
-            //   - useStatsCodec  = true (gating: opt-out does not apply to direct Xtream)
-            //   - Probing is suppressed via hasStats path (ShouldSuppressProbing), so
-            //     SupportsProbing=false / AnalyzeDurationMs=0 still hold here.
-            //   - video MediaStream.Codec declared from stats (codec hint preserved).
-            //   - audio MediaStream.Codec = "aac" honoured.
-
+            // Pass-through profile: the profile has no answer, so the caller passes the codec
+            // from stats and every codec-derived attribute is valid.
             var stats = new StreamStatsInfo
             {
                 VideoCodec = "hevc",
@@ -333,36 +291,115 @@ namespace Emby.Xtream.Plugin.Tests
 
             var source = XtreamTunerHost.CreateMediaSourceInfo(
                 streamId: 12345,
-                streamUrl: "http://xtream.example.com/live/user/pass/12345.ts", // direct Xtream fallback URL
+                streamUrl: "http://dispatcharr.local/proxy/ts/stream/abc-uuid",
                 stats: stats,
-                disableProbing: false,       // isDispatcharr=false path
-                forceAudioTranscode: false,
-                userAgent: null,
-                fallbackBitrateMbps: 0,
-                declareDvbSubtitles: false,
-                useStatsCodec: true);        // post-gate: opt-out does NOT apply to direct Xtream
-
-            // Stats are present, so probing is still suppressed — but via the hasStats
-            // branch of ShouldSuppressProbing, not via the Dispatcharr flag.
-            Assert.False(source.SupportsProbing);
-            Assert.Equal(0, source.AnalyzeDurationMs);
+                disableProbing: true,
+                declaredVideoCodec: "hevc");
 
             var video = Assert.Single(source.MediaStreams, s => s.Type == MediaStreamType.Video);
-            var audio = Assert.Single(source.MediaStreams, s => s.Type == MediaStreamType.Audio);
-
-            // Direct Xtream fallback: codec hint preserved, NOT stripped by the opt-out.
             Assert.Equal("hevc", video.Codec);
             Assert.Equal("1080p HEVC", video.DisplayTitle);
-
-            // Audio codec honoured.
-            Assert.Equal("aac", audio.Codec);
-
-            // The other side of the codec-derived gate: with the codec trusted, profile,
-            // level, bit depth and reference frames are declared alongside it.
             Assert.Equal("Main", video.Profile);
             Assert.Equal(41.0, video.Level);
             Assert.Equal(10, video.BitDepth);
             Assert.Equal(4, video.RefFrames);
+        }
+
+        [Fact]
+        public void CreateMediaSourceInfo_NeverDeclaresNullVideoCodec()
+        {
+            // Codex review on PR #67 flagged this as critical: the no-stats branch documents
+            // that Emby's RecordingRequiresEncoding dereferences MediaStream.Codec, so a null
+            // codec turns a recording into a NullReferenceException. No configuration may
+            // produce one — not a caller with no answer, not stats that carry no codec.
+            var statsWithoutCodec = new StreamStatsInfo
+            {
+                Resolution = "1920x1080",
+                Bitrate = 4500,
+            };
+
+            var source = XtreamTunerHost.CreateMediaSourceInfo(
+                streamId: 12345,
+                streamUrl: "http://dispatcharr.local/proxy/ts/stream/abc-uuid",
+                stats: statsWithoutCodec,
+                disableProbing: true,
+                declaredVideoCodec: null);
+
+            var video = Assert.Single(source.MediaStreams, s => s.Type == MediaStreamType.Video);
+            Assert.False(string.IsNullOrEmpty(video.Codec));
+            Assert.Equal("h264", video.Codec);
+
+            // Same guarantee on the no-stats path, which has always used the H.264 fallback.
+            var noStats = XtreamTunerHost.CreateMediaSourceInfo(
+                streamId: 12345,
+                streamUrl: "http://dispatcharr.local/proxy/ts/stream/abc-uuid",
+                stats: null,
+                disableProbing: true,
+                declaredVideoCodec: null);
+            var noStatsVideo = Assert.Single(noStats.MediaStreams, s => s.Type == MediaStreamType.Video);
+            Assert.Equal("h264", noStatsVideo.Codec);
+        }
+
+        [Fact]
+        public void CreateMediaSourceInfo_AudioOnlyChannel_IsUnaffectedByTheCodecDecision()
+        {
+            // Audio-only channels build no video stream at all, whatever the caller declares.
+            var stats = new StreamStatsInfo
+            {
+                AudioCodec = "aac",
+                AudioBitrate = 128,
+                AudioChannels = "stereo",
+            };
+
+            var source = XtreamTunerHost.CreateMediaSourceInfo(
+                streamId: 12345,
+                streamUrl: "http://dispatcharr.local/proxy/ts/stream/abc-uuid",
+                stats: stats,
+                disableProbing: true,
+                declaredVideoCodec: "h264");
+
+            Assert.DoesNotContain(source.MediaStreams, s => s.Type == MediaStreamType.Video);
+            var audio = Assert.Single(source.MediaStreams, s => s.Type == MediaStreamType.Audio);
+            Assert.Equal("aac", audio.Codec);
+            Assert.Equal(0, source.DefaultAudioStreamIndex);
+        }
+
+        [Fact]
+        public void CreateMediaSourceInfo_DirectXtreamFallback_UsesReportedCodec()
+        {
+            // When BuildStreamUrl falls back to a direct Xtream URL the bytes are the
+            // provider's own, so ResolveVideoCodec hands the factory the reported codec even
+            // when a Dispatcharr profile is cached for the channel.
+            var statsCodec = XtreamTunerHost.MapVideoCodec("hevc");
+            var declared = XtreamTunerHost.ResolveVideoCodec(
+                isDispatcharr: false, codecSource: "auto", profileCodec: "h264", statsCodec: statsCodec);
+
+            var source = XtreamTunerHost.CreateMediaSourceInfo(
+                streamId: 12345,
+                streamUrl: "http://xtream.example.com/live/user/pass/12345.ts",
+                stats: new StreamStatsInfo { VideoCodec = "hevc", AudioCodec = "aac", Resolution = "1920x1080" },
+                disableProbing: false,
+                declaredVideoCodec: declared);
+
+            // Stats are present, so probing is still suppressed — via the hasStats branch of
+            // ShouldSuppressProbing, not via the Dispatcharr flag.
+            Assert.False(source.SupportsProbing);
+
+            var video = Assert.Single(source.MediaStreams, s => s.Type == MediaStreamType.Video);
+            Assert.Equal("hevc", video.Codec);
+            Assert.Equal("1080p HEVC", video.DisplayTitle);
+        }
+
+        // -------------------------------------------------------------------------
+        // Placeholder for deferred full integration tests. See class-level XML doc for
+        // the planned scenarios — they require refactoring the static _streamStats
+        // cache to instance-level before they can run with isolation. This Fact runs
+        // (not skipped) so the suite still tracks the work item.
+        // -------------------------------------------------------------------------
+        [Fact]
+        public void Placeholder_StaticStreamStatsCachePreventsIsolation()
+        {
+            Assert.True(true, "Placeholder: defer full XtreamTunerHost scenarios until _streamStats is instance-level.");
         }
     }
 }

--- a/Emby.Xtream.Plugin.Tests/XtreamTunerHostTests.cs
+++ b/Emby.Xtream.Plugin.Tests/XtreamTunerHostTests.cs
@@ -1,42 +1,124 @@
+using Emby.Xtream.Plugin.Service;
 using Xunit;
 
 namespace Emby.Xtream.Plugin.Tests
 {
     /// <summary>
-    /// Placeholder for XtreamTunerHost tests.
+    /// Regression tests for issue #66 — Dispatcharr's <c>stream_stats.video_codec</c> field
+    /// is the codec Dispatcharr *ingested* from the source, not the codec it *emits*.
+    /// On a channel whose Dispatcharr stream profile transcodes video (e.g. HEVC source
+    /// → H.264 output) the plugin was declaring the source codec and setting
+    /// <c>SupportsProbing=false</c>, which forced Emby to apply the wrong decoder and
+    /// the channel failed to play.
     ///
-    /// Full integration tests are deferred because XtreamTunerHost.GetChannelStreamMediaSources
-    /// relies on a static ConcurrentDictionary (_streamStats) for stream statistics, making
-    /// test isolation between test runs impossible without further refactoring of the stats
-    /// lifecycle (e.g., making it instance-level or injecting a stats provider).
-    ///
-    /// Planned tests once the static state is addressed:
-    /// - Dispatcharr path: enabled → MediaSourceInfo.Path is /proxy/ts/stream/{uuid}, SupportsProbing=false
-    /// - Direct Xtream path: Dispatcharr disabled → path is raw Xtream stream URL
-    /// - AC3 → 6 channels, EAC3 → 6 channels, MP2 → 2 channels, unknown codec → no channel count
-    /// - Stats for wrong stream ID → no-stats defaults applied
-    /// - SupportsDirectStream: stats present → true; no stats → false
-    /// - ForceAudioTranscode config flag reflected on media source
-    /// - UserAgent propagation
+    /// The fix: <see cref="PluginConfiguration.DispatcharrUseStatsCodec"/> (default true).
+    /// When false, the plugin ignores the VideoCodec from stream_stats, collapses
+    /// <c>hasStats</c> to audio-only-or-absent, and lets Emby probe the proxy URL to
+    /// discover the real output codec. The placeholder for full integration tests
+    /// remains — this file exercises the static decision helper, which is enough to
+    /// pin the bug-fix logic without touching the static <c>_streamStats</c> cache.
     /// </summary>
     public class XtreamTunerHostTests
     {
+        [Theory]
+        // (disableProbing, hasStats, expected) — pins the helper's truth table. The helper
+        // is intentionally just `disableProbing || hasStats`. The decision lives in the
+        // helper, but the call site wires `effectiveDisableProbing = disableProbing && useStatsCodec`
+        // (issue #66) so probing is allowed when the user has opted out of stats codec.
+        [InlineData(true, true, true)]
+        // Audio-only path with stats (hasStats=true via isAudioOnly, even with no video).
+        // Probing still suppressed — there's no video stream to discover.
+        [InlineData(true, false, true)]
+        // Non-Dispatcharr path (direct Xtream URL) with stats: legacy behavior suppresses
+        // probing. Stats are accurate because there's no proxy transcoding.
+        [InlineData(false, true, true)]
+        // No stats, no Dispatcharr flag: probe, fall back to ffprobe.
+        [InlineData(false, false, false)]
+        public void ShouldSuppressProbing_MatchesLegacyTruthTable(bool disableProbing, bool hasStats, bool expected)
+        {
+            // The helper is intentionally just `disableProbing || hasStats`. This test pins
+            // that identity — if anyone tries to "simplify" it later, the truth-table will
+            // catch the change and they'll need to update both the test and the ADR.
+            Assert.Equal(expected, XtreamTunerHost.ShouldSuppressProbing(disableProbing, hasStats));
+        }
+
+        [Fact]
+        public void ShouldSuppressProbing_DisableProbingFlagAloneSuppresses()
+        {
+            // The Dispatcharr path always calls CreateMediaSourceInfo with
+            // disableProbing=true. The fix in CreateMediaSourceInfo (#66) is to AND the
+            // disableProbing flag with useStatsCodec BEFORE calling this helper, so the
+            // helper itself still receives the raw disableProbing/hasStats pair. This
+            // test documents that contract: when disableProbing is true, probing is
+            // suppressed regardless of hasStats. The escape route for #66 lives in the
+            // caller, not the helper.
+            Assert.True(XtreamTunerHost.ShouldSuppressProbing(
+                disableProbing: true,
+                hasStats: false));
+        }
+
+        [Fact]
+        public void ShouldSuppressProbing_HasStatsAloneSuppresses()
+        {
+            // Audio-only path: stats have AudioCodec but no VideoCodec. hasStats is true
+            // (via the audio-only branch). Even with disableProbing false, probing is
+            // suppressed — there's no video to probe for and the helper shouldn't second-
+            // guess the caller's intent.
+            Assert.True(XtreamTunerHost.ShouldSuppressProbing(
+                disableProbing: false,
+                hasStats: true));
+        }
+
+        [Theory]
+        // Issue #66 escape: the dispatcharr-side disable flag is dropped when the user
+        // has opted out of the stats codec. The helper pins the wiring logic so the
+        // bug can't regress without both the helper and the test changing.
+        [InlineData(true, false, false)]   // Dispatcharr + user opted out → probing allowed
+        [InlineData(true, true, true)]     // Dispatcharr + default (legacy) → suppress
+        [InlineData(false, false, false)]  // Direct Xtream + user opted out → probing allowed
+        [InlineData(false, true, false)]   // Direct Xtream + default → probing allowed
+        public void ShouldDisableProbing_Issue66DropsFlagWhenUserOptsOut(
+            bool disableProbing, bool useStatsCodec, bool expected)
+        {
+            Assert.Equal(expected, XtreamTunerHost.ShouldDisableProbing(disableProbing, useStatsCodec));
+        }
+
+        [Fact]
+        public void Issue66_EndToEnd_DispatcharrWithStatsUserOptsOutOfCodec_ProbingRuns()
+        {
+            // Hand-walk through the call-site logic with the reporter's exact bug inputs:
+            //   - dispatcharr path (disableProbing = true)
+            //   - stats present: VideoCodec = "hevc", AudioCodec = "aac" (Dispatcharr ingested HEVC)
+            //   - user has set DispatcharrUseStatsCodec = false (opt out)
+            // Expected: probing is allowed, so Emby probes the proxy URL and discovers
+            // the real output codec (H.264 in the reporter's setup).
+            bool disableProbing = true;      // XtreamTunerHost passes this when isDispatcharr=true
+            bool useStatsCodec = false;      // DispatcharrUseStatsCodec = false
+
+            // Mimic CreateMediaSourceInfo's hasStats derivation:
+            // hasVideoCodecFromStats = VideoCodec != null && useStatsCodec
+            //                       = true       && false        = false
+            // isAudioOnly = VideoCodec == null && AudioCodec != "" (NOT this case — VideoCodec set)
+            // hasStats = false || false = false
+            bool hasStats = false;
+
+            bool effective = XtreamTunerHost.ShouldDisableProbing(disableProbing, useStatsCodec);
+            bool suppress = XtreamTunerHost.ShouldSuppressProbing(effective, hasStats);
+
+            Assert.False(effective);
+            Assert.False(suppress);
+        }
+
+        // -------------------------------------------------------------------------
+        // Placeholder for deferred full integration tests. See class-level XML doc for
+        // the planned scenarios — they require refactoring the static _streamStats
+        // cache to instance-level before they can run with isolation. This Fact runs
+        // (not skipped) so the suite still tracks the work item.
+        // -------------------------------------------------------------------------
         [Fact]
         public void Placeholder_StaticStreamStatsCachePreventsIsolation()
         {
-            // This is an explicit placeholder for a deferred test scenario.
-            // It runs (not skipped) so the suite still tracks the work item in code review.
-            // See class-level XML doc for planned scenarios.
-            //
-            // Deferred because XtreamTunerHost.GetChannelStreamMediaSources relies on a static
-            // ConcurrentDictionary (_streamStats) for stream statistics, which makes test
-            // isolation between test runs impossible without further refactoring of the stats
-            // lifecycle (e.g., making it instance-level or injecting a stats provider).
-            //
-            // To enable the real assertions, refactor the static _streamStats cache to be
-            // instance-level (or DI-injected), then replace this body with the planned
-            // scenarios listed at the top of this file.
-            Assert.True(true, "Placeholder: defer XtreamTunerHost scenarios until _streamStats is instance-level.");
+            Assert.True(true, "Placeholder: defer full XtreamTunerHost scenarios until _streamStats is instance-level.");
         }
     }
 }

--- a/Emby.Xtream.Plugin.Tests/XtreamTunerHostTests.cs
+++ b/Emby.Xtream.Plugin.Tests/XtreamTunerHostTests.cs
@@ -271,5 +271,75 @@ namespace Emby.Xtream.Plugin.Tests
         {
             Assert.True(true, "Placeholder: defer full XtreamTunerHost scenarios until _streamStats is instance-level.");
         }
+
+        [Theory]
+        // CodeRabbit finding on PR #67 head 8c2e46e: when BuildStreamUrl falls back to a
+        // direct Xtream URL, isDispatcharr=false but _streamStats may still hold Dispatcharr
+        // stats for the channel. Passing config.DispatcharrUseStatsCodec raw then strips
+        // the codec hint from the direct fallback. Stats also suppress probing, so the
+        // fallback loses BOTH codec and probe. ShouldUseStatsCodec gates the opt-out to
+        // Dispatcharr sources only.
+        [InlineData(true, true, true)]    // Dispatcharr + default: opt-out not active
+        [InlineData(true, false, false)]  // Dispatcharr + opt-out: skip codec (issue #66)
+        [InlineData(false, true, true)]   // Direct Xtream + default: trust codec
+        [InlineData(false, false, true)]  // Direct Xtream + opt-out: opt-out N/A, trust codec
+        public void ShouldUseStatsCodec_GatesOptOutToDispatcharrOnly(bool isDispatcharr, bool dispatcharrUseStatsCodec, bool expected)
+        {
+            Assert.Equal(expected, XtreamTunerHost.ShouldUseStatsCodec(isDispatcharr, dispatcharrUseStatsCodec));
+        }
+
+        [Fact]
+        public void CreateMediaSourceInfo_DirectXtreamFallback_RetainsCodecDespiteOptOut()
+        {
+            // CodeRabbit finding on PR #67 head 8c2e46e regression: when BuildStreamUrl
+            // returns a direct Xtream URL but Dispatcharr stats are still cached for the
+            // channel, the opt-out must NOT apply — stats already suppress probing, so
+            // stripping the codec hint leaves the direct fallback with neither codec nor
+            // probe. ShouldUseStatsCodec(now isDispatcharr=false, configOptOut=false) = true,
+            // so the caller hands useStatsCodec=true to the factory. This test pins the
+            // factory output for the post-gate direct-fallback case.
+            //
+            // Expected output for direct Xtream fallback:
+            //   - disableProbing = false (isDispatcharr=false path)
+            //   - useStatsCodec  = true (gating: opt-out does not apply to direct Xtream)
+            //   - Probing is suppressed via hasStats path (ShouldSuppressProbing), so
+            //     SupportsProbing=false / AnalyzeDurationMs=0 still hold here.
+            //   - video MediaStream.Codec declared from stats (codec hint preserved).
+            //   - audio MediaStream.Codec = "aac" honoured.
+
+            var stats = new StreamStatsInfo
+            {
+                VideoCodec = "hevc",
+                AudioCodec = "aac",
+                Resolution = "1920x1080",
+                Bitrate = 4500,
+            };
+
+            var source = XtreamTunerHost.CreateMediaSourceInfo(
+                streamId: 12345,
+                streamUrl: "http://xtream.example.com/live/user/pass/12345.ts", // direct Xtream fallback URL
+                stats: stats,
+                disableProbing: false,       // isDispatcharr=false path
+                forceAudioTranscode: false,
+                userAgent: null,
+                fallbackBitrateMbps: 0,
+                declareDvbSubtitles: false,
+                useStatsCodec: true);        // post-gate: opt-out does NOT apply to direct Xtream
+
+            // Stats are present, so probing is still suppressed — but via the hasStats
+            // branch of ShouldSuppressProbing, not via the Dispatcharr flag.
+            Assert.False(source.SupportsProbing);
+            Assert.Equal(0, source.AnalyzeDurationMs);
+
+            var video = Assert.Single(source.MediaStreams, s => s.Type == MediaStreamType.Video);
+            var audio = Assert.Single(source.MediaStreams, s => s.Type == MediaStreamType.Audio);
+
+            // Direct Xtream fallback: codec hint preserved, NOT stripped by the opt-out.
+            Assert.Equal("hevc", video.Codec);
+            Assert.Equal("1080p HEVC", video.DisplayTitle);
+
+            // Audio codec honoured.
+            Assert.Equal("aac", audio.Codec);
+        }
     }
 }

--- a/Emby.Xtream.Plugin/Client/DispatcharrClient.cs
+++ b/Emby.Xtream.Plugin/Client/DispatcharrClient.cs
@@ -96,8 +96,15 @@ namespace Emby.Xtream.Plugin.Client
         }
 
         /// <summary>
-        /// Reads the <c>default_stream_profile</c> setting: the profile used by channels that
-        /// have none assigned. Returns null when the setting or the endpoint is unavailable.
+        /// Reads the <c>default_stream_profile</c> setting: the profile used by streams and
+        /// channels that have none assigned.
+        /// <para>
+        /// Two shapes are in the wild. Older servers return one flat row per setting
+        /// (<c>{"key": "default_stream_profile", "value": 3}</c>); newer ones group settings
+        /// into blobs and the profile lives inside the <c>stream_settings</c> row's value
+        /// object, which itself arrives either as JSON or as a JSON-encoded string. All three
+        /// are read. Returns null when the setting or the endpoint is unavailable.
+        /// </para>
         /// </summary>
         public async Task<int?> GetDefaultStreamProfileIdAsync(string baseUrl, CancellationToken cancellationToken)
         {
@@ -105,18 +112,40 @@ namespace Emby.Xtream.Plugin.Client
                 baseUrl + "/api/core/settings/",
                 baseUrl, cancellationToken).ConfigureAwait(false);
             if (json == null) return null;
+
             try
             {
-                var settings = JsonSerializer.Deserialize<List<DispatcharrSetting>>(json, JsonOptions);
-                if (settings == null) return null;
-                foreach (var setting in settings)
+                using (var doc = JsonDocument.Parse(json))
                 {
-                    if (!string.Equals(setting.Key, "default_stream_profile", StringComparison.OrdinalIgnoreCase))
-                        continue;
-                    int id;
-                    if (int.TryParse(setting.Value, NumberStyles.None, CultureInfo.InvariantCulture, out id) && id > 0)
-                        return id;
-                    return null;
+                    var root = doc.RootElement;
+                    if (root.ValueKind == JsonValueKind.Object && root.TryGetProperty("results", out var results))
+                        root = results;
+                    if (root.ValueKind != JsonValueKind.Array) return null;
+
+                    foreach (var row in root.EnumerateArray())
+                    {
+                        if (row.ValueKind != JsonValueKind.Object) continue;
+
+                        JsonElement keyElement;
+                        var key = row.TryGetProperty("key", out keyElement) && keyElement.ValueKind == JsonValueKind.String
+                            ? keyElement.GetString()
+                            : null;
+
+                        JsonElement value;
+                        if (!row.TryGetProperty("value", out value)) continue;
+
+                        // Flat row: the setting is the row itself.
+                        if (string.Equals(key, DefaultStreamProfileKey, StringComparison.OrdinalIgnoreCase))
+                        {
+                            var flat = ReadProfileId(value);
+                            if (flat.HasValue) return flat;
+                            continue;
+                        }
+
+                        // Grouped row: the setting is a field inside the blob.
+                        var nested = ReadNestedProfileId(value);
+                        if (nested.HasValue) return nested;
+                    }
                 }
                 return null;
             }
@@ -125,6 +154,64 @@ namespace Emby.Xtream.Plugin.Client
                 _logger.Warn("Could not read Dispatcharr settings: {0}", ex.Message);
                 return null;
             }
+        }
+
+        private const string DefaultStreamProfileKey = "default_stream_profile";
+
+        /// <summary>Reads a profile ID that may be typed as a number or as a string.</summary>
+        private static int? ReadProfileId(JsonElement element)
+        {
+            if (element.ValueKind == JsonValueKind.Number)
+            {
+                int number;
+                return element.TryGetInt32(out number) && number > 0 ? number : (int?)null;
+            }
+            if (element.ValueKind == JsonValueKind.String)
+            {
+                int parsed;
+                return int.TryParse(element.GetString(), NumberStyles.None, CultureInfo.InvariantCulture, out parsed)
+                       && parsed > 0
+                    ? parsed
+                    : (int?)null;
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// Looks for <c>default_stream_profile</c> inside a settings blob, which arrives either
+        /// as a JSON object or as a string holding one.
+        /// </summary>
+        private static int? ReadNestedProfileId(JsonElement value)
+        {
+            if (value.ValueKind == JsonValueKind.Object)
+            {
+                JsonElement nested;
+                return value.TryGetProperty(DefaultStreamProfileKey, out nested) ? ReadProfileId(nested) : null;
+            }
+
+            if (value.ValueKind == JsonValueKind.String)
+            {
+                var raw = value.GetString();
+                if (string.IsNullOrEmpty(raw) || raw.IndexOf(DefaultStreamProfileKey, StringComparison.Ordinal) < 0)
+                    return null;
+                try
+                {
+                    using (var inner = JsonDocument.Parse(raw))
+                    {
+                        JsonElement nested;
+                        return inner.RootElement.ValueKind == JsonValueKind.Object
+                               && inner.RootElement.TryGetProperty(DefaultStreamProfileKey, out nested)
+                            ? ReadProfileId(nested)
+                            : null;
+                    }
+                }
+                catch (JsonException)
+                {
+                    return null;
+                }
+            }
+
+            return null;
         }
 
         /// <summary>
@@ -205,8 +292,10 @@ namespace Emby.Xtream.Plugin.Client
                     if (ch.ChannelNumber.HasValue && !channelNumberMap.ContainsKey(sid))
                         channelNumberMap[sid] = ch.ChannelNumber.Value;
 
+                    // A stream may carry its own profile, which Dispatcharr resolves before the
+                    // channel's. Falling back to 0 means "use the server default profile".
                     if (!streamProfileIdMap.ContainsKey(sid))
-                        streamProfileIdMap[sid] = ch.ResolvedStreamProfileId ?? 0;
+                        streamProfileIdMap[sid] = stream.StreamProfileId ?? ch.ResolvedStreamProfileId ?? 0;
 
                     allowedStreamIds?.Add(sid);
                 }

--- a/Emby.Xtream.Plugin/Client/DispatcharrClient.cs
+++ b/Emby.Xtream.Plugin/Client/DispatcharrClient.cs
@@ -71,6 +71,63 @@ namespace Emby.Xtream.Plugin.Client
         }
 
         /// <summary>
+        /// Fetches the stream profiles. Each one carries the command and arguments Dispatcharr
+        /// runs for a channel, which is what decides the codec leaving the proxy.
+        /// Returns an empty list when the endpoint is unavailable — older Dispatcharr builds
+        /// and restricted accounts both land there, and the caller treats an empty list as
+        /// "cannot tell", falling back to the codec from stream_stats.
+        /// </summary>
+        public async Task<List<DispatcharrStreamProfile>> GetStreamProfilesAsync(string baseUrl, CancellationToken cancellationToken)
+        {
+            var json = await GetAuthenticatedAsync(
+                baseUrl + "/api/core/streamprofiles/",
+                baseUrl, cancellationToken).ConfigureAwait(false);
+            if (json == null) return new List<DispatcharrStreamProfile>();
+            try
+            {
+                return JsonSerializer.Deserialize<List<DispatcharrStreamProfile>>(json, JsonOptions)
+                       ?? new List<DispatcharrStreamProfile>();
+            }
+            catch (JsonException ex)
+            {
+                _logger.Warn("Could not read Dispatcharr stream profiles: {0}", ex.Message);
+                return new List<DispatcharrStreamProfile>();
+            }
+        }
+
+        /// <summary>
+        /// Reads the <c>default_stream_profile</c> setting: the profile used by channels that
+        /// have none assigned. Returns null when the setting or the endpoint is unavailable.
+        /// </summary>
+        public async Task<int?> GetDefaultStreamProfileIdAsync(string baseUrl, CancellationToken cancellationToken)
+        {
+            var json = await GetAuthenticatedAsync(
+                baseUrl + "/api/core/settings/",
+                baseUrl, cancellationToken).ConfigureAwait(false);
+            if (json == null) return null;
+            try
+            {
+                var settings = JsonSerializer.Deserialize<List<DispatcharrSetting>>(json, JsonOptions);
+                if (settings == null) return null;
+                foreach (var setting in settings)
+                {
+                    if (!string.Equals(setting.Key, "default_stream_profile", StringComparison.OrdinalIgnoreCase))
+                        continue;
+                    int id;
+                    if (int.TryParse(setting.Value, NumberStyles.None, CultureInfo.InvariantCulture, out id) && id > 0)
+                        return id;
+                    return null;
+                }
+                return null;
+            }
+            catch (JsonException ex)
+            {
+                _logger.Warn("Could not read Dispatcharr settings: {0}", ex.Message);
+                return null;
+            }
+        }
+
+        /// <summary>
         /// Fetches channels with embedded stream sources in a single API call and returns the
         /// UUID map, stream stats map, TVG-ID map, Gracenote station ID map, and the set of
         /// allowed Xtream stream IDs (when profile filtering is active).
@@ -82,7 +139,7 @@ namespace Emby.Xtream.Plugin.Client
         /// Optional set of Dispatcharr channel IDs (ch.Id) to include.
         /// When null, all channels are included (no profile filtering).
         /// </param>
-        public async Task<(Dictionary<int, string> UuidMap, Dictionary<int, StreamStatsInfo> StatsMap, Dictionary<int, string> TvgIdMap, Dictionary<int, string> StationIdMap, HashSet<int> AllowedStreamIds, Dictionary<int, double> ChannelNumberMap)>
+        public async Task<(Dictionary<int, string> UuidMap, Dictionary<int, StreamStatsInfo> StatsMap, Dictionary<int, string> TvgIdMap, Dictionary<int, string> StationIdMap, HashSet<int> AllowedStreamIds, Dictionary<int, double> ChannelNumberMap, Dictionary<int, int> StreamProfileIdMap)>
             GetChannelDataAsync(string baseUrl, CancellationToken cancellationToken, HashSet<int> enabledChannelIds = null)
         {
             var uuidMap = new Dictionary<int, string>();
@@ -90,15 +147,18 @@ namespace Emby.Xtream.Plugin.Client
             var tvgIdMap = new Dictionary<int, string>();
             var stationIdMap = new Dictionary<int, string>();
             var channelNumberMap = new Dictionary<int, double>();
+            // Value 0 is the sentinel for "this channel has no profile of its own", which
+            // StreamProfileCodec.BuildCodecMap resolves against the server default profile.
+            var streamProfileIdMap = new Dictionary<int, int>();
             HashSet<int> allowedStreamIds = enabledChannelIds != null ? new HashSet<int>() : null;
 
             var json = await GetAuthenticatedAsync(
                 baseUrl + "/api/channels/channels/?include_streams=true&limit=2000",
                 baseUrl, cancellationToken).ConfigureAwait(false);
-            if (json == null) return (uuidMap, statsMap, tvgIdMap, stationIdMap, allowedStreamIds, channelNumberMap);
+            if (json == null) return (uuidMap, statsMap, tvgIdMap, stationIdMap, allowedStreamIds, channelNumberMap, streamProfileIdMap);
 
             var channels = JsonSerializer.Deserialize<List<DispatcharrChannelWithStreams>>(json, JsonOptions);
-            if (channels == null) return (uuidMap, statsMap, tvgIdMap, stationIdMap, allowedStreamIds, channelNumberMap);
+            if (channels == null) return (uuidMap, statsMap, tvgIdMap, stationIdMap, allowedStreamIds, channelNumberMap, streamProfileIdMap);
 
             foreach (var ch in channels)
             {
@@ -145,6 +205,9 @@ namespace Emby.Xtream.Plugin.Client
                     if (ch.ChannelNumber.HasValue && !channelNumberMap.ContainsKey(sid))
                         channelNumberMap[sid] = ch.ChannelNumber.Value;
 
+                    if (!streamProfileIdMap.ContainsKey(sid))
+                        streamProfileIdMap[sid] = ch.ResolvedStreamProfileId ?? 0;
+
                     allowedStreamIds?.Add(sid);
                 }
 
@@ -163,6 +226,8 @@ namespace Emby.Xtream.Plugin.Client
 
                 if (ch.ChannelNumber.HasValue)
                     channelNumberMap[ch.Id] = ch.ChannelNumber.Value;
+
+                streamProfileIdMap[ch.Id] = ch.ResolvedStreamProfileId ?? 0;
 
                 foreach (var stream in ch.Streams)
                 {
@@ -188,7 +253,7 @@ namespace Emby.Xtream.Plugin.Client
                     uuidMap.Count, statsMap.Count, tvgIdMap.Count, stationIdMap.Count);
             }
 
-            return (uuidMap, statsMap, tvgIdMap, stationIdMap, allowedStreamIds, channelNumberMap);
+            return (uuidMap, statsMap, tvgIdMap, stationIdMap, allowedStreamIds, channelNumberMap, streamProfileIdMap);
         }
 
         /// <summary>Returns the Dispatcharr VOD movie detail (UUID) for a given Xtream stream ID.</summary>

--- a/Emby.Xtream.Plugin/Client/Models/DispatcharrChannel.cs
+++ b/Emby.Xtream.Plugin/Client/Models/DispatcharrChannel.cs
@@ -19,6 +19,12 @@ namespace Emby.Xtream.Plugin.Client.Models
 
         [JsonPropertyName("stream_stats")]
         public StreamStatsInfo StreamStats { get; set; }
+
+        // A stream can override the channel's profile; Dispatcharr resolves the stream's own
+        // value first. Null means "fall back to the channel, then to the server default".
+        [JsonPropertyName("stream_profile_id")]
+        [JsonConverter(typeof(TolerantNullableIntConverter))]
+        public int? StreamProfileId { get; set; }
     }
 
     /// <summary>

--- a/Emby.Xtream.Plugin/Client/Models/DispatcharrChannel.cs
+++ b/Emby.Xtream.Plugin/Client/Models/DispatcharrChannel.cs
@@ -50,6 +50,22 @@ namespace Emby.Xtream.Plugin.Client.Models
 
         [JsonPropertyName("streams")]
         public List<DispatcharrChannel> Streams { get; set; } = new List<DispatcharrChannel>();
+
+        // Which stream profile decides what leaves the proxy for this channel. Dispatcharr
+        // resolves an override before the channel's own value, and exposes the result as
+        // effective_stream_profile_id on newer serializers; older ones only carry
+        // stream_profile_id. Prefer the effective value where present, fall back to the
+        // plain one, and treat both being absent as "use the server default profile".
+        [JsonPropertyName("stream_profile_id")]
+        [JsonConverter(typeof(TolerantNullableIntConverter))]
+        public int? StreamProfileId { get; set; }
+
+        [JsonPropertyName("effective_stream_profile_id")]
+        [JsonConverter(typeof(TolerantNullableIntConverter))]
+        public int? EffectiveStreamProfileId { get; set; }
+
+        /// <summary>Profile that actually governs this channel, or null to use the server default.</summary>
+        public int? ResolvedStreamProfileId => EffectiveStreamProfileId ?? StreamProfileId;
     }
 
     /// <summary>

--- a/Emby.Xtream.Plugin/Client/Models/DispatcharrStreamProfile.cs
+++ b/Emby.Xtream.Plugin/Client/Models/DispatcharrStreamProfile.cs
@@ -32,20 +32,4 @@ namespace Emby.Xtream.Plugin.Client.Models
         [JsonPropertyName("locked")]
         public bool? Locked { get; set; }
     }
-
-    /// <summary>
-    /// One key/value row from <c>/api/core/settings/</c>. Only <c>default_stream_profile</c>
-    /// is read: it names the profile used by channels that have none of their own.
-    /// </summary>
-    public class DispatcharrSetting
-    {
-        [JsonPropertyName("key")]
-        public string Key { get; set; }
-
-        // The endpoint types this loosely — a profile ID arrives as a number on some
-        // versions and as a string on others, and unrelated rows hold JSON blobs.
-        [JsonPropertyName("value")]
-        [JsonConverter(typeof(TolerantStringConverter))]
-        public string Value { get; set; }
-    }
 }

--- a/Emby.Xtream.Plugin/Client/Models/DispatcharrStreamProfile.cs
+++ b/Emby.Xtream.Plugin/Client/Models/DispatcharrStreamProfile.cs
@@ -1,0 +1,51 @@
+using System.Text.Json.Serialization;
+
+namespace Emby.Xtream.Plugin.Client.Models
+{
+    /// <summary>
+    /// A Dispatcharr stream profile (<c>/api/core/streamprofiles/</c>).
+    /// <para>
+    /// <see cref="Command"/> is the executable Dispatcharr runs (<c>ffmpeg</c>, <c>streamlink</c>,
+    /// a script, or the built-in redirect/proxy profiles) and <see cref="Parameters"/> holds its
+    /// argument string with <c>{userAgent}</c>, <c>{streamUrl}</c> and <c>{channelId}</c>
+    /// placeholders. Together they decide what codec leaves the proxy, which is the only
+    /// authoritative answer to "what will Emby actually receive" short of probing the stream.
+    /// </para>
+    /// </summary>
+    public class DispatcharrStreamProfile
+    {
+        [JsonPropertyName("id")]
+        public int Id { get; set; }
+
+        [JsonPropertyName("name")]
+        public string Name { get; set; } = string.Empty;
+
+        [JsonPropertyName("command")]
+        public string Command { get; set; }
+
+        [JsonPropertyName("parameters")]
+        public string Parameters { get; set; }
+
+        [JsonPropertyName("is_active")]
+        public bool? IsActive { get; set; }
+
+        [JsonPropertyName("locked")]
+        public bool? Locked { get; set; }
+    }
+
+    /// <summary>
+    /// One key/value row from <c>/api/core/settings/</c>. Only <c>default_stream_profile</c>
+    /// is read: it names the profile used by channels that have none of their own.
+    /// </summary>
+    public class DispatcharrSetting
+    {
+        [JsonPropertyName("key")]
+        public string Key { get; set; }
+
+        // The endpoint types this loosely — a profile ID arrives as a number on some
+        // versions and as a string on others, and unrelated rows hold JSON blobs.
+        [JsonPropertyName("value")]
+        [JsonConverter(typeof(TolerantStringConverter))]
+        public string Value { get; set; }
+    }
+}

--- a/Emby.Xtream.Plugin/Configuration/Web/config.html
+++ b/Emby.Xtream.Plugin/Configuration/Web/config.html
@@ -711,6 +711,21 @@
                                 Dolby Digital passthrough for Apple TV and other clients that support it.
                             </div>
                         </div>
+                        <div class="checkboxContainer checkboxContainer-withDescription" style="margin-top:0.5em;">
+                            <label>
+                                <input class="chkDispatcharrUseStatsCodec" type="checkbox" is="emby-checkbox" />
+                                <span>Declare Dispatcharr's reported video codec</span>
+                            </label>
+                            <div class="fieldDescription checkboxFieldDescription">
+                                Dispatcharr reports the codec it receives from the provider, not the codec
+                                it sends to Emby. Leave this on when your Dispatcharr stream profile passes
+                                video through unchanged. Turn it off if your profile re-encodes video (for
+                                example an HEVC source sent out as H.264) and channels fail with
+                                "No compatible streams are currently available" - Emby then works out the
+                                codec from the stream itself. The player shows resolution only
+                                (e.g. "1080p") instead of resolution plus codec while this is off.
+                            </div>
+                        </div>
                     </div>
                 </div>
 

--- a/Emby.Xtream.Plugin/Configuration/Web/config.html
+++ b/Emby.Xtream.Plugin/Configuration/Web/config.html
@@ -711,19 +711,22 @@
                                 Dolby Digital passthrough for Apple TV and other clients that support it.
                             </div>
                         </div>
-                        <div class="checkboxContainer checkboxContainer-withDescription" style="margin-top:0.5em;">
-                            <label>
-                                <input class="chkDispatcharrUseStatsCodec" type="checkbox" is="emby-checkbox" />
-                                <span>Declare Dispatcharr's reported video codec</span>
-                            </label>
-                            <div class="fieldDescription checkboxFieldDescription">
-                                Dispatcharr reports the codec it receives from the provider, not the codec
-                                it sends to Emby. Leave this on when your Dispatcharr stream profile passes
-                                video through unchanged. Turn it off if your profile re-encodes video (for
-                                example an HEVC source sent out as H.264) and channels fail with
-                                "No compatible streams are currently available" - Emby then works out the
-                                codec from the stream itself. The player shows resolution only
-                                (e.g. "1080p") instead of resolution plus codec while this is off.
+                        <div class="selectContainer" style="margin-top:0.5em;">
+                            <select class="selDispatcharrCodecSource" is="emby-select" label="Video codec for Dispatcharr channels">
+                                <option value="auto">Automatic (recommended)</option>
+                                <option value="stats">Use the codec Dispatcharr reports</option>
+                                <option value="h264">Always H.264</option>
+                                <option value="hevc">Always HEVC</option>
+                            </select>
+                            <div class="fieldDescription">
+                                Dispatcharr reports the codec it receives from the provider, which is not
+                                the same thing as the codec it sends to Emby when your stream profile
+                                re-encodes video. <b>Automatic</b> reads your stream profile and uses what
+                                it actually outputs, falling back to the reported codec for profiles that
+                                pass video through untouched. Pick one of the other options only if a
+                                channel plays with the wrong codec: <b>Use the codec Dispatcharr reports</b>
+                                is the old behaviour, and the two fixed choices are for setups where the
+                                plugin cannot read your stream profiles.
                             </div>
                         </div>
                     </div>

--- a/Emby.Xtream.Plugin/Configuration/Web/config.js
+++ b/Emby.Xtream.Plugin/Configuration/Web/config.js
@@ -438,6 +438,7 @@ function (BaseView, loading) {
             view.querySelector('.txtDispatcharrPass').value = config.DispatcharrPass || '';
             view.querySelector('.chkDispatcharrFallback').checked = config.DispatcharrFallbackToXtream !== false;
             view.querySelector('.chkForceAudioTranscode').checked = !!config.ForceAudioTranscode;
+            view.querySelector('.chkDispatcharrUseStatsCodec').checked = config.DispatcharrUseStatsCodec !== false;
             view.querySelector('.chkDeclareDvbSubtitles').checked = !!config.DeclareDvbSubtitles;
 
             instance.selectedDispatcharrProfileIds = config.SelectedDispatcharrProfileIds || [];
@@ -567,6 +568,7 @@ function (BaseView, loading) {
             if (_dPwdVal) config.DispatcharrPass = _dPwdVal;
             config.DispatcharrFallbackToXtream = view.querySelector('.chkDispatcharrFallback').checked;
             config.ForceAudioTranscode = view.querySelector('.chkForceAudioTranscode').checked;
+            config.DispatcharrUseStatsCodec = view.querySelector('.chkDispatcharrUseStatsCodec').checked;
             config.DeclareDvbSubtitles = view.querySelector('.chkDeclareDvbSubtitles').checked;
             config.SelectedDispatcharrProfileIds = getSelectedDispatcharrProfileIds(instance);
 

--- a/Emby.Xtream.Plugin/Configuration/Web/config.js
+++ b/Emby.Xtream.Plugin/Configuration/Web/config.js
@@ -438,7 +438,7 @@ function (BaseView, loading) {
             view.querySelector('.txtDispatcharrPass').value = config.DispatcharrPass || '';
             view.querySelector('.chkDispatcharrFallback').checked = config.DispatcharrFallbackToXtream !== false;
             view.querySelector('.chkForceAudioTranscode').checked = !!config.ForceAudioTranscode;
-            view.querySelector('.chkDispatcharrUseStatsCodec').checked = config.DispatcharrUseStatsCodec !== false;
+            view.querySelector('.selDispatcharrCodecSource').value = config.DispatcharrVideoCodecSource || 'auto';
             view.querySelector('.chkDeclareDvbSubtitles').checked = !!config.DeclareDvbSubtitles;
 
             instance.selectedDispatcharrProfileIds = config.SelectedDispatcharrProfileIds || [];
@@ -568,7 +568,7 @@ function (BaseView, loading) {
             if (_dPwdVal) config.DispatcharrPass = _dPwdVal;
             config.DispatcharrFallbackToXtream = view.querySelector('.chkDispatcharrFallback').checked;
             config.ForceAudioTranscode = view.querySelector('.chkForceAudioTranscode').checked;
-            config.DispatcharrUseStatsCodec = view.querySelector('.chkDispatcharrUseStatsCodec').checked;
+            config.DispatcharrVideoCodecSource = view.querySelector('.selDispatcharrCodecSource').value;
             config.DeclareDvbSubtitles = view.querySelector('.chkDeclareDvbSubtitles').checked;
             config.SelectedDispatcharrProfileIds = getSelectedDispatcharrProfileIds(instance);
 

--- a/Emby.Xtream.Plugin/PluginConfiguration.cs
+++ b/Emby.Xtream.Plugin/PluginConfiguration.cs
@@ -50,27 +50,28 @@ namespace Emby.Xtream.Plugin
         public bool DeclareDvbSubtitles { get; set; }
 
         /// <summary>
-        /// When true (default), the plugin declares the codec Dispatcharr reports via
-        /// <c>stream_stats.video_codec</c> as the expected codec on the Live TV
-        /// MediaSource. That field is the codec Dispatcharr *ingested* from the
-        /// source, not the codec Dispatcharr *emits*. When the Dispatcharr stream
-        /// profile transcodes (e.g. HEVC source → H.264 output), declaring the
-        /// source codec causes Emby to force the wrong decoder and the channel
-        /// fails to play (issue #66).
-        ///
-        /// Set to false to skip the video codec declaration on Dispatcharr URLs.
-        /// Emby then picks whatever decoder the actual MPEG-TS bytes need and the
-        /// channel plays. Probing stays disabled for Dispatcharr proxy URLs (see
-        /// <c>docs/AGENTS.md</c>). Trade-off: the player UI shows resolution only
-        /// (e.g. "1080p") instead of resolution + codec (e.g. "1080p H264") for the
-        /// affected channels, and the codec-derived attributes go with it (profile,
-        /// level, bit depth, reference frames) since they describe the ingested codec.
-        /// Resolution, FPS, bitrate, and everything on the audio stream keep flowing
-        /// from <c>stream_stats</c> regardless of this flag.
-        /// Exposed as <c>Declare Dispatcharr's reported video codec</c> in the
-        /// Dispatcharr section of the plugin config page.
+        /// Where the video codec declared to Emby for Dispatcharr channels comes from.
+        /// <para>
+        /// <c>auto</c> (default) reads the channel's Dispatcharr stream profile and declares
+        /// what that profile emits, falling back to <c>stream_stats.video_codec</c> when the
+        /// profile passes video through or cannot be read. This is the fix for issue #66:
+        /// <c>stream_stats.video_codec</c> is the codec Dispatcharr <em>ingested</em>, so on a
+        /// transcoding profile (HEVC source, H.264 output) declaring it makes Emby force the
+        /// wrong decoder and the channel fails to play.
+        /// </para>
+        /// <para>
+        /// <c>stats</c> always declares the reported codec, the behaviour before #66, and is
+        /// the escape hatch if profile detection ever reads a profile wrongly. <c>h264</c> and
+        /// <c>hevc</c> declare that codec on every Dispatcharr channel, for installs where the
+        /// profile endpoint is unreachable but the output is known.
+        /// </para>
+        /// <para>
+        /// Exposed as <c>Video codec for Dispatcharr channels</c> in the Dispatcharr section of
+        /// the plugin config page. An empty value (config XML written before this setting
+        /// existed) is read as <c>auto</c>.
+        /// </para>
         /// </summary>
-        public bool DispatcharrUseStatsCodec { get; set; } = true;
+        public string DispatcharrVideoCodecSource { get; set; } = "auto";
         public int[] SelectedDispatcharrProfileIds { get; set; } = new int[0];
         public string CachedDispatcharrProfiles { get; set; } = string.Empty;
 

--- a/Emby.Xtream.Plugin/PluginConfiguration.cs
+++ b/Emby.Xtream.Plugin/PluginConfiguration.cs
@@ -58,12 +58,13 @@ namespace Emby.Xtream.Plugin
         /// source codec causes Emby to force the wrong decoder and the channel
         /// fails to play (issue #66).
         ///
-        /// Set to false to skip codec declarations on Dispatcharr URLs and let
-        /// Emby probe the proxy for the actual output codec. This re-enables
-        /// probing, which adds ~100ms on first tune per channel and may surface
-        /// the Dispatcharr teardown storm on installs whose
-        /// <c>channel_shutdown_delay</c> is zero (set it to a positive value in
-        /// Dispatcharr to avoid that).
+        /// Set to false to skip the video codec declaration on Dispatcharr URLs.
+        /// Emby then picks whatever decoder the actual MPEG-TS bytes need and the
+        /// channel plays. Probing stays disabled for Dispatcharr proxy URLs (see
+        /// <c>docs/AGENTS.md</c>). Trade-off: the player UI shows resolution only
+        /// (e.g. "1080p") instead of resolution + codec (e.g. "1080p H264") for the
+        /// affected channels. Resolution, FPS, bitrate, profile, level, and audio
+        /// codec keep flowing from <c>stream_stats</c> regardless of this flag.
         /// </summary>
         public bool DispatcharrUseStatsCodec { get; set; } = true;
         public int[] SelectedDispatcharrProfileIds { get; set; } = new int[0];

--- a/Emby.Xtream.Plugin/PluginConfiguration.cs
+++ b/Emby.Xtream.Plugin/PluginConfiguration.cs
@@ -48,6 +48,24 @@ namespace Emby.Xtream.Plugin
         public bool DispatcharrFallbackToXtream { get; set; } = true;
         public bool ForceAudioTranscode { get; set; }
         public bool DeclareDvbSubtitles { get; set; }
+
+        /// <summary>
+        /// When true (default), the plugin declares the codec Dispatcharr reports via
+        /// <c>stream_stats.video_codec</c> as the expected codec on the Live TV
+        /// MediaSource. That field is the codec Dispatcharr *ingested* from the
+        /// source, not the codec Dispatcharr *emits*. When the Dispatcharr stream
+        /// profile transcodes (e.g. HEVC source → H.264 output), declaring the
+        /// source codec causes Emby to force the wrong decoder and the channel
+        /// fails to play (issue #66).
+        ///
+        /// Set to false to skip codec declarations on Dispatcharr URLs and let
+        /// Emby probe the proxy for the actual output codec. This re-enables
+        /// probing, which adds ~100ms on first tune per channel and may surface
+        /// the Dispatcharr teardown storm on installs whose
+        /// <c>channel_shutdown_delay</c> is zero (set it to a positive value in
+        /// Dispatcharr to avoid that).
+        /// </summary>
+        public bool DispatcharrUseStatsCodec { get; set; } = true;
         public int[] SelectedDispatcharrProfileIds { get; set; } = new int[0];
         public string CachedDispatcharrProfiles { get; set; } = string.Empty;
 

--- a/Emby.Xtream.Plugin/PluginConfiguration.cs
+++ b/Emby.Xtream.Plugin/PluginConfiguration.cs
@@ -63,8 +63,12 @@ namespace Emby.Xtream.Plugin
         /// channel plays. Probing stays disabled for Dispatcharr proxy URLs (see
         /// <c>docs/AGENTS.md</c>). Trade-off: the player UI shows resolution only
         /// (e.g. "1080p") instead of resolution + codec (e.g. "1080p H264") for the
-        /// affected channels. Resolution, FPS, bitrate, profile, level, and audio
-        /// codec keep flowing from <c>stream_stats</c> regardless of this flag.
+        /// affected channels, and the codec-derived attributes go with it (profile,
+        /// level, bit depth, reference frames) since they describe the ingested codec.
+        /// Resolution, FPS, bitrate, and everything on the audio stream keep flowing
+        /// from <c>stream_stats</c> regardless of this flag.
+        /// Exposed as <c>Declare Dispatcharr's reported video codec</c> in the
+        /// Dispatcharr section of the plugin config page.
         /// </summary>
         public bool DispatcharrUseStatsCodec { get; set; } = true;
         public int[] SelectedDispatcharrProfileIds { get; set; } = new int[0];

--- a/Emby.Xtream.Plugin/Service/StreamProfileCodec.cs
+++ b/Emby.Xtream.Plugin/Service/StreamProfileCodec.cs
@@ -47,11 +47,21 @@ namespace Emby.Xtream.Plugin.Service
             // ffmpeg applies the last matching option, so hand-tuned profiles that set a codec
             // twice ("-c:v copy" early, a real encoder later) must resolve to the later one.
             string encoder = null;
-            for (int i = 0; i + 1 < tokens.Length; i++)
+            for (int i = 0; i < tokens.Length; i++)
             {
-                if (IsVideoCodecFlag(tokens[i]))
+                var token = Unquote(tokens[i]);
+
+                // "-c:v=h264_nvenc": flag and value in one token.
+                var equals = token.IndexOf('=');
+                if (equals > 0 && IsVideoCodecFlag(token.Substring(0, equals)))
                 {
-                    encoder = tokens[i + 1];
+                    encoder = Unquote(token.Substring(equals + 1));
+                    continue;
+                }
+
+                if (i + 1 < tokens.Length && IsVideoCodecFlag(token))
+                {
+                    encoder = Unquote(tokens[i + 1]);
                 }
             }
 
@@ -106,6 +116,17 @@ namespace Emby.Xtream.Plugin.Service
             }
 
             return result;
+        }
+
+        /// <summary>
+        /// Strips the quotes profiles sometimes carry around a value ("-c:v \"h264_nvenc\"").
+        /// The parameters string is written by hand in Dispatcharr's UI, so both quote styles
+        /// turn up, and an encoder left with its quotes on would read as unrecognised.
+        /// </summary>
+        private static string Unquote(string token)
+        {
+            if (string.IsNullOrEmpty(token)) return token;
+            return token.Trim('"', '\'');
         }
 
         private static bool IsVideoCodecFlag(string token)

--- a/Emby.Xtream.Plugin/Service/StreamProfileCodec.cs
+++ b/Emby.Xtream.Plugin/Service/StreamProfileCodec.cs
@@ -1,0 +1,148 @@
+using System;
+using System.Collections.Generic;
+using Emby.Xtream.Plugin.Client.Models;
+
+namespace Emby.Xtream.Plugin.Service
+{
+    /// <summary>
+    /// Works out which video codec a Dispatcharr stream profile emits, by reading the
+    /// profile's own ffmpeg arguments.
+    /// <para>
+    /// Dispatcharr's <c>stream_stats.video_codec</c> reports what it ingested from the
+    /// provider. When the profile transcodes, that is not what Emby receives, and declaring
+    /// it forces the wrong decoder (issue #66). The profile is the one place that states the
+    /// output, and reading it costs a cached API call rather than a probe of the stream.
+    /// </para>
+    /// <para>
+    /// Everything that cannot be identified with confidence returns null, which the caller
+    /// reads as "no answer" and falls back to the reported codec. Guessing is worse than
+    /// deferring: a wrong declaration is the bug this class exists to fix.
+    /// </para>
+    /// </summary>
+    internal static class StreamProfileCodec
+    {
+        private static readonly char[] TokenSeparators = { ' ', '\t', '\r', '\n' };
+
+        /// <summary>
+        /// Returns the codec a profile emits ("h264", "hevc", "mpeg2video"), or null when the
+        /// profile passes video through untouched, is not an ffmpeg profile, or uses an
+        /// encoder this parser does not recognise.
+        /// </summary>
+        internal static string Parse(string command, string parameters)
+        {
+            if (string.IsNullOrWhiteSpace(parameters)) return null;
+
+            // Non-ffmpeg profiles (the built-in redirect and proxy profiles, streamlink, vlc,
+            // custom scripts) do not re-encode, so the ingested codec is also the emitted one.
+            // An empty command is treated as ffmpeg: some profiles carry the binary in the
+            // parameters string instead.
+            if (!string.IsNullOrWhiteSpace(command)
+                && command.IndexOf("ffmpeg", StringComparison.OrdinalIgnoreCase) < 0)
+            {
+                return null;
+            }
+
+            var tokens = parameters.Split(TokenSeparators, StringSplitOptions.RemoveEmptyEntries);
+
+            // ffmpeg applies the last matching option, so hand-tuned profiles that set a codec
+            // twice ("-c:v copy" early, a real encoder later) must resolve to the later one.
+            string encoder = null;
+            for (int i = 0; i + 1 < tokens.Length; i++)
+            {
+                if (IsVideoCodecFlag(tokens[i]))
+                {
+                    encoder = tokens[i + 1];
+                }
+            }
+
+            return MapEncoder(encoder);
+        }
+
+        /// <summary>
+        /// Builds a stream-id → emitted-codec map from the per-channel profile assignments and
+        /// the profile list. Channels with no profile of their own fall back to the server's
+        /// default profile. Streams whose profile cannot be resolved or parsed are left out of
+        /// the map entirely, so callers see the absence rather than a guess.
+        /// </summary>
+        internal static Dictionary<int, string> BuildCodecMap(
+            Dictionary<int, int> streamProfileIds,
+            List<DispatcharrStreamProfile> profiles,
+            int? defaultProfileId)
+        {
+            var result = new Dictionary<int, string>();
+            if (streamProfileIds == null || streamProfileIds.Count == 0) return result;
+
+            var parsedByProfile = new Dictionary<int, string>();
+            if (profiles != null)
+            {
+                foreach (var profile in profiles)
+                {
+                    var codec = Parse(profile.Command, profile.Parameters);
+                    if (codec != null) parsedByProfile[profile.Id] = codec;
+                }
+            }
+
+            string defaultCodec = null;
+            if (defaultProfileId.HasValue)
+            {
+                parsedByProfile.TryGetValue(defaultProfileId.Value, out defaultCodec);
+            }
+
+            foreach (var entry in streamProfileIds)
+            {
+                string codec;
+                // A profile ID of 0 is the sentinel this map uses for "channel has no profile
+                // of its own", written by the caller when both id fields came back null.
+                if (entry.Value == 0)
+                {
+                    codec = defaultCodec;
+                }
+                else if (!parsedByProfile.TryGetValue(entry.Value, out codec))
+                {
+                    codec = null;
+                }
+
+                if (codec != null) result[entry.Key] = codec;
+            }
+
+            return result;
+        }
+
+        private static bool IsVideoCodecFlag(string token)
+        {
+            if (string.IsNullOrEmpty(token) || token[0] != '-') return false;
+            // "-c" and "-codec" without a stream specifier apply to every stream, video included.
+            return token.Equals("-c:v", StringComparison.OrdinalIgnoreCase)
+                || token.Equals("-codec:v", StringComparison.OrdinalIgnoreCase)
+                || token.Equals("-vcodec", StringComparison.OrdinalIgnoreCase)
+                || token.Equals("-c", StringComparison.OrdinalIgnoreCase)
+                || token.Equals("-codec", StringComparison.OrdinalIgnoreCase)
+                || token.StartsWith("-c:v:", StringComparison.OrdinalIgnoreCase)
+                || token.StartsWith("-codec:v:", StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// Maps an ffmpeg encoder name onto the codec name Emby expects. Unknown encoders
+        /// return null rather than their own name: handing Emby "av1_nvenc" as a codec is
+        /// worse than handing it nothing, because Emby will try to use it.
+        /// </summary>
+        private static string MapEncoder(string encoder)
+        {
+            if (string.IsNullOrEmpty(encoder)) return null;
+            var lower = encoder.ToLowerInvariant();
+
+            // "copy" is passthrough, so the ingested codec is the emitted one. Reported as
+            // null ("no answer from the profile") so the caller uses stats, which already
+            // holds that same codec.
+            if (lower == "copy") return null;
+
+            if (lower == "libx264" || lower.StartsWith("h264", StringComparison.Ordinal)) return "h264";
+            if (lower == "libx265"
+                || lower.StartsWith("hevc", StringComparison.Ordinal)
+                || lower.StartsWith("h265", StringComparison.Ordinal)) return "hevc";
+            if (lower.StartsWith("mpeg2", StringComparison.Ordinal)) return "mpeg2video";
+
+            return null;
+        }
+    }
+}

--- a/Emby.Xtream.Plugin/Service/XtreamTunerHost.cs
+++ b/Emby.Xtream.Plugin/Service/XtreamTunerHost.cs
@@ -1459,7 +1459,14 @@ namespace Emby.Xtream.Plugin.Service
             // decoder and the channel fails to play (issue #66). Resolution, FPS, bitrate,
             // and audio codec are independent of video transcoding and stay honoured.
             bool hasVideoCodecFromStats = stats?.VideoCodec != null && useStatsCodec;
-            bool hasStats = hasVideoCodecFromStats || isAudioOnly;
+            // hasStats reflects "Dispatcharr returned stats for this channel", NOT
+            // "the video codec from stats is trusted". The opt-out only suppresses the
+            // video codec (via ShouldDeclareVideoCodec); resolution, FPS, bitrate, audio
+            // codec, audio channels, profile, and level stay honoured. Previously this
+            // was `hasVideoCodecFromStats || isAudioOnly`, which dropped ALL stats for
+            // video channels with DispatcharrUseStatsCodec=false — caught by CodeRabbit
+            // review on PR #67 head 3c6d056.
+            bool hasStats = HasStats(stats != null, isAudioOnly);
 
             // Disable probing for Dispatcharr proxy URLs: the probe opens a short-lived HTTP
             // connection that Dispatcharr interprets as a client, and when it closes after
@@ -1783,6 +1790,28 @@ namespace Emby.Xtream.Plugin.Service
         internal static bool ShouldSuppressProbing(bool disableProbing, bool hasStats)
         {
             return disableProbing || hasStats;
+        }
+
+        /// <summary>
+        /// Decides whether the Live TV <c>MediaSource</c> should populate stat-derived
+        /// fields (resolution, FPS, bitrate, audio codec, audio channels, video profile,
+        /// level, bit depth, reference frames). True iff Dispatcharr returned stats for
+        /// the channel — independent of <c>DispatcharrUseStatsCodec</c>, which only
+        /// suppresses the video <em>codec</em> declaration via <see cref="ShouldDeclareVideoCodec"/>.
+        /// Regression test for issue #66 follow-up: the original
+        /// <c>hasVideoCodecFromStats || isAudioOnly</c> expression dropped every stat
+        /// on a video channel with the opt-out on, leaving Emby with no resolution, no
+        /// FPS, and no audio info. CodeRabbit review on PR #67 head 3c6d056.
+        /// </summary>
+        internal static bool HasStats(bool statsPresent, bool isAudioOnly)
+        {
+            // statsPresent mirrors "stats != null" upstream; isAudioOnly is implied by
+            // statsPresent (it requires stats.VideoCodec == null && AudioCodec != ""),
+            // so the helper returns statsPresent alone. Kept as a two-argument signature
+            // for symmetry with ShouldSuppressProbing and to document the audio-only
+            // assumption at the call site.
+            _ = isAudioOnly;
+            return statsPresent;
         }
 
         /// <summary>

--- a/Emby.Xtream.Plugin/Service/XtreamTunerHost.cs
+++ b/Emby.Xtream.Plugin/Service/XtreamTunerHost.cs
@@ -391,12 +391,16 @@ namespace Emby.Xtream.Plugin.Service
                             config.SelectedDispatcharrProfileIds.Length, enabledChannelIds.Count);
                     }
 
+                    // Started first so the two small profile requests ride along with the big
+                    // channel-data request instead of queueing behind it.
+                    var profileFetch = StartStreamProfileFetch(config.DispatcharrUrl, cancellationToken);
+
                     var (uuidMap, statsMap, tvgIdMap, stationIdMap, allowedStreamIds, channelNumberMap, streamProfileIdMap) =
                         await _dispatcharrClient.GetChannelDataAsync(
                             config.DispatcharrUrl, cancellationToken, enabledChannelIds).ConfigureAwait(false);
                     newStats = statsMap;
-                    newProfileCodecs = await BuildProfileCodecMapAsync(
-                        config.DispatcharrUrl, streamProfileIdMap, cancellationToken).ConfigureAwait(false);
+                    newProfileCodecs = await BuildProfileCodecMapAsync(profileFetch, streamProfileIdMap)
+                        .ConfigureAwait(false);
                     _channelUuidMap = uuidMap;
                     _tvgIdMap = tvgIdMap;
                     _stationIdMap = stationIdMap;
@@ -1402,12 +1406,17 @@ namespace Emby.Xtream.Plugin.Service
                     }
                 }
 
+                // This runs inside a tune, so the profile requests are started up front and
+                // awaited alongside the channel data rather than after it: two extra serial
+                // round trips in front of playback is the BUG-007 shape.
+                var profileFetch = StartStreamProfileFetch(config.DispatcharrUrl, cancellationToken);
+
                 var (uuidMap, statsMap, tvgIdMap, stationIdMap, allowedStreamIds, channelNumberMap, streamProfileIdMap) =
                     await _dispatcharrClient.GetChannelDataAsync(
                         config.DispatcharrUrl, cancellationToken, enabledChannelIds).ConfigureAwait(false);
                 if (statsMap.Count > 0) _streamStats = statsMap;
-                var profileCodecs = await BuildProfileCodecMapAsync(
-                    config.DispatcharrUrl, streamProfileIdMap, cancellationToken).ConfigureAwait(false);
+                var profileCodecs = await BuildProfileCodecMapAsync(profileFetch, streamProfileIdMap)
+                    .ConfigureAwait(false);
                 if (profileCodecs.Count > 0) _streamProfileCodecs = profileCodecs;
                 if (uuidMap.Count > 0) _channelUuidMap = uuidMap;
                 if (tvgIdMap.Count > 0) _tvgIdMap = tvgIdMap;
@@ -1471,29 +1480,41 @@ namespace Emby.Xtream.Plugin.Service
         }
 
         /// <summary>
-        /// Reads the Dispatcharr stream profiles and the server default, and turns them into a
-        /// stream-id → emitted-codec map. Runs on the cached refresh path only: doing this per
-        /// playback is what BUG-007 was about. Every failure mode degrades to an empty map,
-        /// which means the codec from stream_stats is used exactly as before.
+        /// Starts the two stream-profile requests without awaiting them, so they overlap with
+        /// the channel-data request that follows. On the on-demand path this matters: that runs
+        /// during a tune, and serialising extra Dispatcharr round trips in front of playback is
+        /// what BUG-007 was about.
+        /// </summary>
+        private (Task<List<DispatcharrStreamProfile>> Profiles, Task<int?> DefaultId) StartStreamProfileFetch(
+            string dispatcharrUrl, CancellationToken cancellationToken)
+        {
+            return (
+                _dispatcharrClient.GetStreamProfilesAsync(dispatcharrUrl, cancellationToken),
+                _dispatcharrClient.GetDefaultStreamProfileIdAsync(dispatcharrUrl, cancellationToken));
+        }
+
+        /// <summary>
+        /// Turns the in-flight profile requests plus the per-stream profile assignments into a
+        /// stream-id → emitted-codec map. Every failure mode degrades to an empty map, which
+        /// means the codec from stream_stats is used exactly as before.
         /// </summary>
         private async Task<Dictionary<int, string>> BuildProfileCodecMapAsync(
-            string dispatcharrUrl, Dictionary<int, int> streamProfileIds, CancellationToken cancellationToken)
+            (Task<List<DispatcharrStreamProfile>> Profiles, Task<int?> DefaultId) fetch,
+            Dictionary<int, int> streamProfileIds)
         {
-            if (streamProfileIds == null || streamProfileIds.Count == 0)
-                return new Dictionary<int, string>();
-
             try
             {
-                var profiles = await _dispatcharrClient
-                    .GetStreamProfilesAsync(dispatcharrUrl, cancellationToken).ConfigureAwait(false);
+                var profiles = await fetch.Profiles.ConfigureAwait(false);
+                var defaultProfileId = await fetch.DefaultId.ConfigureAwait(false);
+
+                if (streamProfileIds == null || streamProfileIds.Count == 0)
+                    return new Dictionary<int, string>();
+
                 if (profiles == null || profiles.Count == 0)
                 {
                     Logger.Info("Dispatcharr stream profiles unavailable — falling back to the reported codec");
                     return new Dictionary<int, string>();
                 }
-
-                var defaultProfileId = await _dispatcharrClient
-                    .GetDefaultStreamProfileIdAsync(dispatcharrUrl, cancellationToken).ConfigureAwait(false);
 
                 var map = StreamProfileCodec.BuildCodecMap(streamProfileIds, profiles, defaultProfileId);
                 Logger.Info("Resolved output codec from Dispatcharr stream profiles for {0} of {1} streams",

--- a/Emby.Xtream.Plugin/Service/XtreamTunerHost.cs
+++ b/Emby.Xtream.Plugin/Service/XtreamTunerHost.cs
@@ -39,6 +39,10 @@ namespace Emby.Xtream.Plugin.Service
         private readonly IServerApplicationHost _applicationHost;
 
         private volatile Dictionary<int, StreamStatsInfo> _streamStats = new Dictionary<int, StreamStatsInfo>();
+        // Stream ID -> codec the channel's Dispatcharr stream profile emits. Built during the
+        // cached channel refresh, never at playback time: reading it per play is how BUG-007
+        // put ~3s on the first tune. Absent key means "profile says nothing", not "passthrough".
+        private volatile Dictionary<int, string> _streamProfileCodecs = new Dictionary<int, string>();
         private volatile Dictionary<int, string> _channelUuidMap = new Dictionary<int, string>();
         private volatile Dictionary<int, string> _tvgIdMap = new Dictionary<int, string>();
         private volatile Dictionary<int, string> _stationIdMap = new Dictionary<int, string>();
@@ -329,6 +333,7 @@ namespace Emby.Xtream.Plugin.Service
 
             var liveTvService = Plugin.Instance.LiveTvService;
             var newStats = new Dictionary<int, StreamStatsInfo>();
+            var newProfileCodecs = new Dictionary<int, string>();
 
             // All three fetches run concurrently; each handles its own errors internally.
             async Task<List<Client.Models.LiveStreamInfo>> channelsFetch()
@@ -386,10 +391,12 @@ namespace Emby.Xtream.Plugin.Service
                             config.SelectedDispatcharrProfileIds.Length, enabledChannelIds.Count);
                     }
 
-                    var (uuidMap, statsMap, tvgIdMap, stationIdMap, allowedStreamIds, channelNumberMap) =
+                    var (uuidMap, statsMap, tvgIdMap, stationIdMap, allowedStreamIds, channelNumberMap, streamProfileIdMap) =
                         await _dispatcharrClient.GetChannelDataAsync(
                             config.DispatcharrUrl, cancellationToken, enabledChannelIds).ConfigureAwait(false);
                     newStats = statsMap;
+                    newProfileCodecs = await BuildProfileCodecMapAsync(
+                        config.DispatcharrUrl, streamProfileIdMap, cancellationToken).ConfigureAwait(false);
                     _channelUuidMap = uuidMap;
                     _tvgIdMap = tvgIdMap;
                     _stationIdMap = stationIdMap;
@@ -508,6 +515,7 @@ namespace Emby.Xtream.Plugin.Service
             }).ToList();
 
             _streamStats = newStats;
+            _streamProfileCodecs = newProfileCodecs;
             _tunerChannelIdToStreamId = newTunerChannelIdToStreamId;
             _cachedChannels = result;
             _cacheTime = DateTime.UtcNow;
@@ -911,13 +919,18 @@ namespace Emby.Xtream.Plugin.Service
 
             _streamStats.TryGetValue(streamId, out var stats);
 
-            // DispatcharrUseStatsCodec only governs the Dispatcharr code path. When BuildStreamUrl
-            // falls back to a direct Xtream URL, the codec opt-out must not apply — stats already
-            // suppress probing, so dropping the codec hint leaves the direct fallback with neither
-            // codec declaration nor probe. ShouldUseStatsCodec pins this gate.
-            var useStatsCodec = ShouldUseStatsCodec(isDispatcharr, config.DispatcharrUseStatsCodec);
+            // What Emby is told the video codec is. On the Dispatcharr path the answer comes from
+            // the channel's stream profile, which states what the proxy emits; stream_stats only
+            // says what it ingested, and those differ whenever the profile transcodes (issue #66).
+            // A direct Xtream fallback URL carries the ingested codec by definition, so the
+            // profile does not apply there.
+            string profileCodec;
+            _streamProfileCodecs.TryGetValue(streamId, out profileCodec);
+            var declaredVideoCodec = ResolveVideoCodec(
+                isDispatcharr, config.DispatcharrVideoCodecSource, profileCodec,
+                stats?.VideoCodec != null ? MapVideoCodec(stats.VideoCodec) : null);
 
-            var mediaSource = CreateMediaSourceInfo(streamId, streamUrl, stats, isDispatcharr, config.ForceAudioTranscode, config.HttpUserAgent, config.FallbackTranscodeBitrateMbps, config.DeclareDvbSubtitles, useStatsCodec, Logger);
+            var mediaSource = CreateMediaSourceInfo(streamId, streamUrl, stats, isDispatcharr, config.ForceAudioTranscode, config.HttpUserAgent, config.FallbackTranscodeBitrateMbps, config.DeclareDvbSubtitles, declaredVideoCodec, Logger);
             Logger.Info("[stream-timing] ch={0} CreateMediaSource={1}ms hasStats={2}", tunerChannel?.Name, sw.ElapsedMilliseconds, stats != null);
 
             return new List<MediaSourceInfo> { mediaSource };
@@ -951,13 +964,18 @@ namespace Emby.Xtream.Plugin.Service
             Logger.Info("[stream-timing] ch={0} BuildUrl={1}ms isDispatcharr={2}", tunerChannel?.Name, sw.ElapsedMilliseconds, isDispatcharr);
             sw.Restart();
 
-            // DispatcharrUseStatsCodec only governs the Dispatcharr code path. When BuildStreamUrl
-            // falls back to a direct Xtream URL, the codec opt-out must not apply — stats already
-            // suppress probing, so dropping the codec hint leaves the direct fallback with neither
-            // codec declaration nor probe. ShouldUseStatsCodec pins this gate.
-            var useStatsCodec = ShouldUseStatsCodec(isDispatcharr, config.DispatcharrUseStatsCodec);
+            // What Emby is told the video codec is. On the Dispatcharr path the answer comes from
+            // the channel's stream profile, which states what the proxy emits; stream_stats only
+            // says what it ingested, and those differ whenever the profile transcodes (issue #66).
+            // A direct Xtream fallback URL carries the ingested codec by definition, so the
+            // profile does not apply there.
+            string profileCodec;
+            _streamProfileCodecs.TryGetValue(streamId, out profileCodec);
+            var declaredVideoCodec = ResolveVideoCodec(
+                isDispatcharr, config.DispatcharrVideoCodecSource, profileCodec,
+                stats?.VideoCodec != null ? MapVideoCodec(stats.VideoCodec) : null);
 
-            var mediaSource = CreateMediaSourceInfo(streamId, streamUrl, stats, isDispatcharr, config.ForceAudioTranscode, config.HttpUserAgent, config.FallbackTranscodeBitrateMbps, config.DeclareDvbSubtitles, useStatsCodec, Logger);
+            var mediaSource = CreateMediaSourceInfo(streamId, streamUrl, stats, isDispatcharr, config.ForceAudioTranscode, config.HttpUserAgent, config.FallbackTranscodeBitrateMbps, config.DeclareDvbSubtitles, declaredVideoCodec, Logger);
             Logger.Info("[stream-timing] ch={0} CreateMediaSource={1}ms hasStats={2}", tunerChannel?.Name, sw.ElapsedMilliseconds, stats != null);
 
             var httpClient = Plugin.CreateHttpClient();
@@ -988,6 +1006,7 @@ namespace Emby.Xtream.Plugin.Service
             _cachedChannels = null;
             _cacheTime = DateTime.MinValue;
             _streamStats = new Dictionary<int, StreamStatsInfo>();
+            _streamProfileCodecs = new Dictionary<int, string>();
             _channelUuidMap = new Dictionary<int, string>();
             _tvgIdMap = new Dictionary<int, string>();
             _stationIdMap = new Dictionary<int, string>();
@@ -1383,10 +1402,13 @@ namespace Emby.Xtream.Plugin.Service
                     }
                 }
 
-                var (uuidMap, statsMap, tvgIdMap, stationIdMap, allowedStreamIds, channelNumberMap) =
+                var (uuidMap, statsMap, tvgIdMap, stationIdMap, allowedStreamIds, channelNumberMap, streamProfileIdMap) =
                     await _dispatcharrClient.GetChannelDataAsync(
                         config.DispatcharrUrl, cancellationToken, enabledChannelIds).ConfigureAwait(false);
                 if (statsMap.Count > 0) _streamStats = statsMap;
+                var profileCodecs = await BuildProfileCodecMapAsync(
+                    config.DispatcharrUrl, streamProfileIdMap, cancellationToken).ConfigureAwait(false);
+                if (profileCodecs.Count > 0) _streamProfileCodecs = profileCodecs;
                 if (uuidMap.Count > 0) _channelUuidMap = uuidMap;
                 if (tvgIdMap.Count > 0) _tvgIdMap = tvgIdMap;
                 if (stationIdMap.Count > 0) _stationIdMap = stationIdMap;
@@ -1448,6 +1470,43 @@ namespace Emby.Xtream.Plugin.Service
                 config.BaseUrl, Uri.EscapeDataString(config.Username ?? string.Empty), Uri.EscapeDataString(config.Password ?? string.Empty), streamId, extension), false);
         }
 
+        /// <summary>
+        /// Reads the Dispatcharr stream profiles and the server default, and turns them into a
+        /// stream-id → emitted-codec map. Runs on the cached refresh path only: doing this per
+        /// playback is what BUG-007 was about. Every failure mode degrades to an empty map,
+        /// which means the codec from stream_stats is used exactly as before.
+        /// </summary>
+        private async Task<Dictionary<int, string>> BuildProfileCodecMapAsync(
+            string dispatcharrUrl, Dictionary<int, int> streamProfileIds, CancellationToken cancellationToken)
+        {
+            if (streamProfileIds == null || streamProfileIds.Count == 0)
+                return new Dictionary<int, string>();
+
+            try
+            {
+                var profiles = await _dispatcharrClient
+                    .GetStreamProfilesAsync(dispatcharrUrl, cancellationToken).ConfigureAwait(false);
+                if (profiles == null || profiles.Count == 0)
+                {
+                    Logger.Info("Dispatcharr stream profiles unavailable — falling back to the reported codec");
+                    return new Dictionary<int, string>();
+                }
+
+                var defaultProfileId = await _dispatcharrClient
+                    .GetDefaultStreamProfileIdAsync(dispatcharrUrl, cancellationToken).ConfigureAwait(false);
+
+                var map = StreamProfileCodec.BuildCodecMap(streamProfileIds, profiles, defaultProfileId);
+                Logger.Info("Resolved output codec from Dispatcharr stream profiles for {0} of {1} streams",
+                    map.Count, streamProfileIds.Count);
+                return map;
+            }
+            catch (Exception ex)
+            {
+                Logger.Warn("Could not resolve Dispatcharr stream profile codecs: {0}", ex.Message);
+                return new Dictionary<int, string>();
+            }
+        }
+
         // internal static so the factory can be exercised by unit tests without an
         // XtreamTunerHost instance (the constructor requires IServerApplicationHost).
         // The factory is otherwise pure: it touches no instance state. Three debug logs
@@ -1457,33 +1516,30 @@ namespace Emby.Xtream.Plugin.Service
             int streamId, string streamUrl, StreamStatsInfo stats,
             bool disableProbing = false, bool forceAudioTranscode = false,
             string userAgent = null, int fallbackBitrateMbps = 0, bool declareDvbSubtitles = false,
-            bool useStatsCodec = true, ILogger logger = null)
+            string declaredVideoCodec = null, ILogger logger = null)
         {
             var sourceId = "xtream_live_" + streamId.ToString(CultureInfo.InvariantCulture);
 
             // Audio-only channel: Dispatcharr stats are present but no video_codec exists.
             // The normal hasStats gate (VideoCodec != null) would fall through to the dummy
             // H.264 fallback, which causes Emby to expect a video stream that isn't there.
-            // Audio detection is independent of useStatsCodec — audio_codec is reliable in
-            // both pass-through and transcoded Dispatcharr stream profiles.
+            // Audio detection is independent of the video codec question — audio_codec is
+            // reliable in both pass-through and transcoded Dispatcharr stream profiles.
             bool isAudioOnly = stats != null
                 && stats.VideoCodec == null
                 && !string.IsNullOrEmpty(stats.AudioCodec);
 
-            // When useStatsCodec is false, treat the video codec from stream_stats as absent:
-            // it is the codec Dispatcharr *ingested* from the source, not the codec it
-            // *emits*. If the Dispatcharr stream profile transcodes (e.g. HEVC source →
-            // H.264 output), declaring the source codec forces Emby to apply the wrong
-            // decoder and the channel fails to play (issue #66). Resolution, FPS, bitrate,
-            // and audio codec are independent of video transcoding and stay honoured.
-            bool hasVideoCodecFromStats = stats?.VideoCodec != null && useStatsCodec;
+            // The codec from stream_stats is what Dispatcharr ingested. The caller decides what
+            // is actually declared (see ResolveVideoCodec) and passes it in; a null means it had
+            // no better answer, so the ingested codec stands.
+            var statsVideoCodec = stats?.VideoCodec != null ? MapVideoCodec(stats.VideoCodec) : null;
+
             // hasStats reflects "Dispatcharr returned stats for this channel", NOT
-            // "the video codec from stats is trusted". The opt-out only suppresses the
-            // video codec (via ShouldDeclareVideoCodec); resolution, FPS, bitrate, audio
-            // codec, audio channels, profile, and level stay honoured. Previously this
-            // was `hasVideoCodecFromStats || isAudioOnly`, which dropped ALL stats for
-            // video channels with DispatcharrUseStatsCodec=false — caught by CodeRabbit
-            // review on PR #67 head 3c6d056.
+            // "the video codec from stats is trusted": resolution, FPS, bitrate, audio
+            // codec and audio channels are honoured whatever the codec turns out to be.
+            // Previously this was `hasVideoCodecFromStats || isAudioOnly`, which dropped
+            // ALL stats for video channels with the codec opt-out on — caught by
+            // CodeRabbit review on PR #67 head 3c6d056.
             bool hasStats = HasStats(stats != null, isAudioOnly);
 
             // Disable probing for Dispatcharr proxy URLs: the probe opens a short-lived HTTP
@@ -1492,8 +1548,8 @@ namespace Emby.Xtream.Plugin.Service
             // connection then hits the teardown and fails, causing a rapid retry storm.
             // AGENTS.md makes this rule absolute: probing MUST stay disabled for Dispatcharr
             // proxy URLs regardless of stats availability. The fix for issue #66 lives in
-            // the codec declaration path (see ShouldDeclareVideoCodec + the MediaStream
-            // build below), not in relaxing this flag.
+            // the codec declaration path (see ResolveVideoCodec + the MediaStream build
+            // below), not in relaxing this flag.
             bool suppressProbing = ShouldSuppressProbing(disableProbing, hasStats);
 
             var audioCodecLower = hasStats && !string.IsNullOrEmpty(stats.AudioCodec)
@@ -1551,8 +1607,17 @@ namespace Emby.Xtream.Plugin.Service
                         }
                     }
 
-                    var declareVideoCodec = ShouldDeclareVideoCodec(hasVideoCodecFromStats, useStatsCodec);
-                    var videoCodec = declareVideoCodec ? MapVideoCodec(stats.VideoCodec) : null;
+                    // Never hand Emby a null codec. The no-stats branch below documents why:
+                    // RecordingRequiresEncoding dereferences the field, so a recording on a
+                    // channel with no codec throws instead of starting. H.264 is the same
+                    // fallback that branch uses and the overwhelmingly common IPTV output.
+                    var videoCodec = !string.IsNullOrEmpty(declaredVideoCodec)
+                        ? declaredVideoCodec
+                        : (statsVideoCodec ?? "h264");
+
+                    // Profile, level, bit depth and reference frames describe the ingested
+                    // codec. They only carry over when what we declare IS that codec.
+                    var declareCodecAttributes = ShouldDeclareCodecAttributes(videoCodec, statsVideoCodec);
 
                     var videoStream = new MediaStream
                     {
@@ -1573,13 +1638,11 @@ namespace Emby.Xtream.Plugin.Service
                     }
                     if (stats.Bitrate.HasValue) videoStream.BitRate = (int)(stats.Bitrate.Value * 1000);
 
-                    // Profile, level, bit depth and reference frames describe the codec Dispatcharr
-                    // ingested, so they are only as trustworthy as the codec itself. When the stream
-                    // profile transcodes (issue #66) they describe the source, not the bytes Emby
-                    // receives: a level number means something different in HEVC than in H.264, and
-                    // bit depth and reference frames need not survive a re-encode. Resolution, FPS
-                    // and ffmpeg_output_bitrate describe the output and stay honoured either way.
-                    if (declareVideoCodec)
+                    // When the profile transcodes, these describe the source rather than the bytes
+                    // Emby receives: a level number means something different in HEVC than in
+                    // H.264, and bit depth and reference frames need not survive a re-encode.
+                    // Resolution, FPS and ffmpeg_output_bitrate describe the output either way.
+                    if (declareCodecAttributes)
                     {
                         if (!string.IsNullOrEmpty(stats.VideoProfile))
                             videoStream.Profile = stats.VideoProfile;
@@ -1806,6 +1869,13 @@ namespace Emby.Xtream.Plugin.Service
                 && (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps);
         }
 
+        // Values accepted by PluginConfiguration.DispatcharrVideoCodecSource. Anything else,
+        // including the empty string an upgraded config XML starts with, means automatic.
+        internal const string CodecSourceAuto = "auto";
+        internal const string CodecSourceStats = "stats";
+        internal const string CodecSourceH264 = "h264";
+        internal const string CodecSourceHevc = "hevc";
+
         internal static string MapVideoCodec(string dispatcharrCodec)
         {
             var upper = dispatcharrCodec.ToUpperInvariant();
@@ -1834,8 +1904,8 @@ namespace Emby.Xtream.Plugin.Service
         /// Decides whether the Live TV <c>MediaSource</c> should populate stat-derived
         /// fields (resolution, FPS, bitrate, audio codec, audio channels, video profile,
         /// level, bit depth, reference frames). True iff Dispatcharr returned stats for
-        /// the channel — independent of <c>DispatcharrUseStatsCodec</c>, which only
-        /// suppresses the video <em>codec</em> declaration via <see cref="ShouldDeclareVideoCodec"/>.
+        /// the channel — independent of which codec ends up declared, which
+        /// <see cref="ResolveVideoCodec"/> decides separately.
         /// Regression test for issue #66 follow-up: the original
         /// <c>hasVideoCodecFromStats || isAudioOnly</c> expression dropped every stat
         /// on a video channel with the opt-out on, leaving Emby with no resolution, no
@@ -1853,53 +1923,63 @@ namespace Emby.Xtream.Plugin.Service
         }
 
         /// <summary>
-        /// Decides whether the plugin should declare the video codec from stream_stats on
-        /// the Live TV <c>MediaStream</c>. When <paramref name="useStatsCodec"/> is false,
-        /// the codec field from stream_stats is the codec Dispatcharr *ingested* from the
-        /// source, not the codec it *emits*. Declaring it on a transcoded Dispatcharr stream
-        /// profile forces Emby to apply the wrong decoder (issue #66). The fix is to leave
-        /// the codec unset and let Emby pick whatever decoder the actual output bytes need
-        /// — without probing, since probing is forbidden for Dispatcharr proxy URLs.
+        /// Decides which video codec is declared on the Live TV <c>MediaStream</c>.
+        /// <para>
+        /// On the Dispatcharr path the profile wins: it states what the proxy emits, while
+        /// <c>stream_stats.video_codec</c> only reports what Dispatcharr ingested. Those differ
+        /// whenever the stream profile transcodes, and declaring the ingested codec is what made
+        /// every HEVC-sourced channel fail to play in issue #66.
+        /// </para>
+        /// <para>
+        /// A direct Xtream URL carries the provider's own bytes, so the ingested codec is the
+        /// right answer there and the Dispatcharr setting does not apply. Returns null when
+        /// nothing is known, which the factory turns into its H.264 fallback rather than a null
+        /// codec.
+        /// </para>
         /// </summary>
-        internal static bool ShouldDeclareVideoCodec(bool hasVideoCodecFromStats, bool useStatsCodec)
+        internal static string ResolveVideoCodec(
+            bool isDispatcharr, string codecSource, string profileCodec, string statsCodec)
         {
-            // Truth table:
-            //   hasVideoCodecFromStats | useStatsCodec | declare?
-            //   true                   | true          | yes (legacy pass-through)
-            //   true                   | false         | no  (issue #66: opt-out)
-            //   false                  | true          | no  (no codec in stats)
-            //   false                  | false         | no  (no codec in stats)
-            // Belt-and-braces: the upstream caller already AND-ed these into
-            // hasVideoCodecFromStats, but re-checking useStatsCodec here means a caller
-            // that forgets to mask upstream still gets the right answer.
-            return hasVideoCodecFromStats && useStatsCodec;
+            if (!isDispatcharr) return statsCodec;
+
+            switch ((codecSource ?? string.Empty).Trim().ToLowerInvariant())
+            {
+                // Pre-#66 behaviour: trust what Dispatcharr reports. Correct for pass-through
+                // profiles and available as an escape when detection reads a profile wrongly.
+                case CodecSourceStats:
+                    return statsCodec;
+
+                // Manual overrides for installs where the profile cannot be read at all
+                // (restricted account, older Dispatcharr) but the user knows the output.
+                case CodecSourceH264:
+                    return "h264";
+                case CodecSourceHevc:
+                    return "hevc";
+
+                // Automatic (default): the profile when it gave an answer, otherwise the
+                // reported codec, which leaves pass-through installs exactly as they were.
+                default:
+                    return profileCodec ?? statsCodec;
+            }
         }
 
         /// <summary>
-        /// Gates the <see cref="PluginConfiguration.DispatcharrUseStatsCodec"/> opt-out to
-        /// Dispatcharr sources. When <paramref name="isDispatcharr"/> is false (direct Xtream
-        /// fallback from <see cref="BuildStreamUrl"/>), stats already suppress probing, so
-        /// dropping the codec hint would leave the direct fallback with neither codec
-        /// declaration nor probe. Treat direct Xtream sources as codec-trusted by default.
-        /// Regression for CodeRabbit finding on PR #67 head 8c2e46e.
+        /// Decides whether the codec-specific attributes from <c>stream_stats</c> (profile,
+        /// level, bit depth, reference frames) may be declared. They describe the ingested
+        /// codec, so they only hold when that is also the codec being declared.
         /// </summary>
-        internal static bool ShouldUseStatsCodec(bool isDispatcharr, bool dispatcharrUseStatsCodec)
+        internal static bool ShouldDeclareCodecAttributes(string declaredCodec, string statsCodec)
         {
-            // Truth table:
-            //   isDispatcharr | dispatcharrUseStatsCodec | useStatsCodec?
-            //   true          | true                     | true  (Dispatcharr + default)
-            //   true          | false                    | false (Dispatcharr + opt-out, issue #66)
-            //   false         | true                     | true  (direct Xtream + default)
-            //   false         | false                    | true  (direct Xtream: opt-out N/A)
-            return !isDispatcharr || dispatcharrUseStatsCodec;
+            return !string.IsNullOrEmpty(declaredCodec)
+                && !string.IsNullOrEmpty(statsCodec)
+                && string.Equals(declaredCodec, statsCodec, StringComparison.OrdinalIgnoreCase);
         }
 
         /// <summary>
         /// Builds the human-readable title for the Live TV video <c>MediaStream</c>.
-        /// Resolved by <see cref="ShouldDeclareVideoCodec"/>: when the codec is trusted,
-        /// include it ("1080p H264"); when it is not (issue #66 opt-out), fall back to
-        /// height-only ("1080p") so the user still gets a useful label without claiming
-        /// a specific codec.
+        /// The codec is resolved by <see cref="ResolveVideoCodec"/> and is never empty on the
+        /// stats path, so the usual shape is "1080p H264". The height-only and codec-only
+        /// shapes cover stats that carry no parsable resolution.
         /// </summary>
         internal static string BuildVideoDisplayTitle(int height, string videoCodec)
         {

--- a/Emby.Xtream.Plugin/Service/XtreamTunerHost.cs
+++ b/Emby.Xtream.Plugin/Service/XtreamTunerHost.cs
@@ -1446,32 +1446,30 @@ namespace Emby.Xtream.Plugin.Service
             // Audio-only channel: Dispatcharr stats are present but no video_codec exists.
             // The normal hasStats gate (VideoCodec != null) would fall through to the dummy
             // H.264 fallback, which causes Emby to expect a video stream that isn't there.
+            // Audio detection is independent of useStatsCodec — audio_codec is reliable in
+            // both pass-through and transcoded Dispatcharr stream profiles.
             bool isAudioOnly = stats != null
                 && stats.VideoCodec == null
                 && !string.IsNullOrEmpty(stats.AudioCodec);
 
-            // When useStatsCodec is false on a Dispatcharr URL, ignore the codec field from
-            // stream_stats entirely. That field is the codec Dispatcharr *ingested* from the
-            // source, not the codec it *emits*. If the Dispatcharr stream profile transcodes
-            // (e.g. HEVC source → H.264 output), declaring the source codec forces Emby to
-            // apply the wrong decoder and the channel fails to play (issue #66). By treating
-            // the codec as absent we let Emby probe the proxy URL and discover the actual
-            // output. Audio-only detection still works because it uses AudioCodec, which we
-            // keep honouring.
+            // When useStatsCodec is false, treat the video codec from stream_stats as absent:
+            // it is the codec Dispatcharr *ingested* from the source, not the codec it
+            // *emits*. If the Dispatcharr stream profile transcodes (e.g. HEVC source →
+            // H.264 output), declaring the source codec forces Emby to apply the wrong
+            // decoder and the channel fails to play (issue #66). Resolution, FPS, bitrate,
+            // and audio codec are independent of video transcoding and stay honoured.
             bool hasVideoCodecFromStats = stats?.VideoCodec != null && useStatsCodec;
             bool hasStats = hasVideoCodecFromStats || isAudioOnly;
 
             // Disable probing for Dispatcharr proxy URLs: the probe opens a short-lived HTTP
             // connection that Dispatcharr interprets as a client, and when it closes after
-            // analysis (~0.1s) Dispatcharr tears down the channel. The real playback connection
-            // then hits the teardown and fails, causing a rapid retry storm.
-            //
-            // Exception (issue #66): when the user has opted out of the stats codec
-            // (DispatcharrUseStatsCodec=false), the input codec is unknown to be the output
-            // codec, so the source MUST be probed to discover the actual output. Drop the
-            // disableProbing flag in that case — probing is exactly the user-requested escape.
-            bool effectiveDisableProbing = ShouldDisableProbing(disableProbing, useStatsCodec);
-            bool suppressProbing = ShouldSuppressProbing(effectiveDisableProbing, hasStats);
+            // analysis (~0.1s) Dispatcharr tears down the channel. The real playback
+            // connection then hits the teardown and fails, causing a rapid retry storm.
+            // AGENTS.md makes this rule absolute: probing MUST stay disabled for Dispatcharr
+            // proxy URLs regardless of stats availability. The fix for issue #66 lives in
+            // the codec declaration path (see ShouldDeclareVideoCodec + the MediaStream
+            // build below), not in relaxing this flag.
+            bool suppressProbing = ShouldSuppressProbing(disableProbing, hasStats);
 
             var audioCodecLower = hasStats && !string.IsNullOrEmpty(stats.AudioCodec)
                 ? stats.AudioCodec.ToLowerInvariant() : null;
@@ -1528,7 +1526,9 @@ namespace Emby.Xtream.Plugin.Service
                         }
                     }
 
-                    var videoCodec = MapVideoCodec(stats.VideoCodec);
+                    var videoCodec = ShouldDeclareVideoCodec(hasVideoCodecFromStats, useStatsCodec)
+                        ? MapVideoCodec(stats.VideoCodec)
+                        : null;
 
                     var videoStream = new MediaStream
                     {
@@ -1541,9 +1541,7 @@ namespace Emby.Xtream.Plugin.Service
 
                     if (width > 0) videoStream.Width = width;
                     if (height > 0) videoStream.Height = height;
-                    videoStream.DisplayTitle = height > 0
-                        ? $"{height}p {videoCodec.ToUpperInvariant()}"
-                        : videoCodec.ToUpperInvariant();
+                    videoStream.DisplayTitle = BuildVideoDisplayTitle(height, videoCodec);
                     if (stats.SourceFps.HasValue)
                     {
                         videoStream.RealFrameRate = (float)stats.SourceFps.Value;
@@ -1778,10 +1776,9 @@ namespace Emby.Xtream.Plugin.Service
         /// exercise the decision without instantiating a full MediaSourceInfo. Probing
         /// is suppressed on Dispatcharr URLs because the probe opens a short-lived HTTP
         /// connection that Dispatcharr interprets as a client and tears down on close,
-        /// causing a retry storm. The caller decides whether to pass through the
-        /// dispatcharr-side <paramref name="disableProbing"/> flag (issue #66: it must
-        /// be cleared when the user has opted out of stats codec, so probing actually
-        /// runs and Emby discovers the real output codec).
+        /// causing a retry storm. AGENTS.md makes this rule absolute for `/proxy/ts/stream/{uuid}`
+        /// URLs: probing MUST stay off regardless of stats availability. Issue #66 lives
+        /// in the codec-declaration path, not in relaxing this flag.
         /// </summary>
         internal static bool ShouldSuppressProbing(bool disableProbing, bool hasStats)
         {
@@ -1789,16 +1786,50 @@ namespace Emby.Xtream.Plugin.Service
         }
 
         /// <summary>
-        /// Resolves the effective probing-disable flag for the Live TV MediaSource.
-        /// Issue #66: when the user has opted out of the stats codec
-        /// (<paramref name="useStatsCodec"/> = false), the input codec is unknown to
-        /// be the output codec, so probing must run. The dispatcharr-side
-        /// <paramref name="disableProbing"/> flag is dropped in that case. Extracted for
-        /// direct regression testing without instantiating a full MediaSourceInfo.
+        /// Decides whether the plugin should declare the video codec from stream_stats on
+        /// the Live TV <c>MediaStream</c>. When <paramref name="useStatsCodec"/> is false,
+        /// the codec field from stream_stats is the codec Dispatcharr *ingested* from the
+        /// source, not the codec it *emits*. Declaring it on a transcoded Dispatcharr stream
+        /// profile forces Emby to apply the wrong decoder (issue #66). The fix is to leave
+        /// the codec unset and let Emby pick whatever decoder the actual output bytes need
+        /// — without probing, since probing is forbidden for Dispatcharr proxy URLs.
         /// </summary>
-        internal static bool ShouldDisableProbing(bool disableProbing, bool useStatsCodec)
+        internal static bool ShouldDeclareVideoCodec(bool hasVideoCodecFromStats, bool useStatsCodec)
         {
-            return disableProbing && useStatsCodec;
+            // Truth table:
+            //   hasVideoCodecFromStats | useStatsCodec | declare?
+            //   true                   | true          | yes (legacy pass-through)
+            //   true                   | false         | no  (issue #66: opt-out)
+            //   false                  | true          | no  (no codec in stats)
+            //   false                  | false         | no  (no codec in stats)
+            // Belt-and-braces: the upstream caller already AND-ed these into
+            // hasVideoCodecFromStats, but re-checking useStatsCodec here means a caller
+            // that forgets to mask upstream still gets the right answer.
+            return hasVideoCodecFromStats && useStatsCodec;
+        }
+
+        /// <summary>
+        /// Builds the human-readable title for the Live TV video <c>MediaStream</c>.
+        /// Resolved by <see cref="ShouldDeclareVideoCodec"/>: when the codec is trusted,
+        /// include it ("1080p H264"); when it is not (issue #66 opt-out), fall back to
+        /// height-only ("1080p") so the user still gets a useful label without claiming
+        /// a specific codec.
+        /// </summary>
+        internal static string BuildVideoDisplayTitle(int height, string videoCodec)
+        {
+            if (height > 0 && !string.IsNullOrEmpty(videoCodec))
+            {
+                return $"{height}p {videoCodec.ToUpperInvariant()}";
+            }
+            if (height > 0)
+            {
+                return $"{height}p";
+            }
+            if (!string.IsNullOrEmpty(videoCodec))
+            {
+                return videoCodec.ToUpperInvariant();
+            }
+            return null;
         }
     }
 }

--- a/Emby.Xtream.Plugin/Service/XtreamTunerHost.cs
+++ b/Emby.Xtream.Plugin/Service/XtreamTunerHost.cs
@@ -14,6 +14,7 @@ using MediaBrowser.Controller.LiveTv;
 using MediaBrowser.Model.Dto;
 using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.LiveTv;
+using MediaBrowser.Model.Logging;
 using MediaBrowser.Model.MediaInfo;
 using STJ = System.Text.Json;
 
@@ -910,7 +911,7 @@ namespace Emby.Xtream.Plugin.Service
 
             _streamStats.TryGetValue(streamId, out var stats);
 
-            var mediaSource = CreateMediaSourceInfo(streamId, streamUrl, stats, isDispatcharr, config.ForceAudioTranscode, config.HttpUserAgent, config.FallbackTranscodeBitrateMbps, config.DeclareDvbSubtitles, config.DispatcharrUseStatsCodec);
+            var mediaSource = CreateMediaSourceInfo(streamId, streamUrl, stats, isDispatcharr, config.ForceAudioTranscode, config.HttpUserAgent, config.FallbackTranscodeBitrateMbps, config.DeclareDvbSubtitles, config.DispatcharrUseStatsCodec, Logger);
             Logger.Info("[stream-timing] ch={0} CreateMediaSource={1}ms hasStats={2}", tunerChannel?.Name, sw.ElapsedMilliseconds, stats != null);
 
             return new List<MediaSourceInfo> { mediaSource };
@@ -944,7 +945,7 @@ namespace Emby.Xtream.Plugin.Service
             Logger.Info("[stream-timing] ch={0} BuildUrl={1}ms isDispatcharr={2}", tunerChannel?.Name, sw.ElapsedMilliseconds, isDispatcharr);
             sw.Restart();
 
-            var mediaSource = CreateMediaSourceInfo(streamId, streamUrl, stats, isDispatcharr, config.ForceAudioTranscode, config.HttpUserAgent, config.FallbackTranscodeBitrateMbps, config.DeclareDvbSubtitles, config.DispatcharrUseStatsCodec);
+            var mediaSource = CreateMediaSourceInfo(streamId, streamUrl, stats, isDispatcharr, config.ForceAudioTranscode, config.HttpUserAgent, config.FallbackTranscodeBitrateMbps, config.DeclareDvbSubtitles, config.DispatcharrUseStatsCodec, Logger);
             Logger.Info("[stream-timing] ch={0} CreateMediaSource={1}ms hasStats={2}", tunerChannel?.Name, sw.ElapsedMilliseconds, stats != null);
 
             var httpClient = Plugin.CreateHttpClient();
@@ -1435,11 +1436,16 @@ namespace Emby.Xtream.Plugin.Service
                 config.BaseUrl, Uri.EscapeDataString(config.Username ?? string.Empty), Uri.EscapeDataString(config.Password ?? string.Empty), streamId, extension), false);
         }
 
-        private MediaSourceInfo CreateMediaSourceInfo(
+        // internal static so the factory can be exercised by unit tests without an
+        // XtreamTunerHost instance (the constructor requires IServerApplicationHost).
+        // The factory is otherwise pure: it touches no instance state. Three debug logs
+        // route through LogDebug so the static signature stays clean — pass null to
+        // suppress logging in tests, pass an ILogger in production callsites.
+        internal static MediaSourceInfo CreateMediaSourceInfo(
             int streamId, string streamUrl, StreamStatsInfo stats,
             bool disableProbing = false, bool forceAudioTranscode = false,
             string userAgent = null, int fallbackBitrateMbps = 0, bool declareDvbSubtitles = false,
-            bool useStatsCodec = true)
+            bool useStatsCodec = true, ILogger logger = null)
         {
             var sourceId = "xtream_live_" + streamId.ToString(CultureInfo.InvariantCulture);
 
@@ -1664,7 +1670,7 @@ namespace Emby.Xtream.Plugin.Service
 
                 if (isAudioOnly)
                 {
-                    Logger.Debug(
+                    LogDebug(logger,
                         "Stream {0}: audio-only - {1} {2}ch{3}",
                         streamId, audioCodecLower ?? "unknown",
                         audioChannels.HasValue ? audioChannels.Value.ToString(CultureInfo.InvariantCulture) : "?",
@@ -1682,7 +1688,7 @@ namespace Emby.Xtream.Plugin.Service
                             int.TryParse(parts[1], NumberStyles.None, CultureInfo.InvariantCulture, out height);
                         }
                     }
-                    Logger.Debug(
+                    LogDebug(logger,
                         "Stream {0}: using stats - {1} {2}x{3} @{4}fps, audio {5} {6}ch{7}",
                         streamId, stats.VideoCodec, width, height,
                         stats.SourceFps, audioCodecLower ?? "unknown",
@@ -1729,12 +1735,22 @@ namespace Emby.Xtream.Plugin.Service
 
                 mediaSource.MediaStreams = new List<MediaStream> { videoStream, audioStream };
                 mediaSource.DefaultAudioStreamIndex = 1;
-                Logger.Debug(
+                LogDebug(logger,
                     "Stream {0}: no stats available, will probe (fallback bitrate {1} Mbps)",
                     streamId, fallbackBitrateMbps);
             }
 
             return mediaSource;
+        }
+
+        // Null-tolerant debug logger. Production callsites pass an ILogger pulled from
+        // BaseTunerHost.Logger; unit tests pass null to suppress log noise. The factory
+        // is otherwise pure — wrapping the log call in a null check keeps the static
+        // signature without forcing test infrastructure to stub an IServerApplicationHost.
+        private static void LogDebug(ILogger logger, string format, params object[] args)
+        {
+            if (logger == null) return;
+            logger.Debug(format, args);
         }
 
         /// <summary>
@@ -1768,7 +1784,7 @@ namespace Emby.Xtream.Plugin.Service
                 && (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps);
         }
 
-        private static string MapVideoCodec(string dispatcharrCodec)
+        internal static string MapVideoCodec(string dispatcharrCodec)
         {
             var upper = dispatcharrCodec.ToUpperInvariant();
             if (upper == "H264" || upper == "AVC") return "h264";

--- a/Emby.Xtream.Plugin/Service/XtreamTunerHost.cs
+++ b/Emby.Xtream.Plugin/Service/XtreamTunerHost.cs
@@ -911,7 +911,13 @@ namespace Emby.Xtream.Plugin.Service
 
             _streamStats.TryGetValue(streamId, out var stats);
 
-            var mediaSource = CreateMediaSourceInfo(streamId, streamUrl, stats, isDispatcharr, config.ForceAudioTranscode, config.HttpUserAgent, config.FallbackTranscodeBitrateMbps, config.DeclareDvbSubtitles, config.DispatcharrUseStatsCodec, Logger);
+            // DispatcharrUseStatsCodec only governs the Dispatcharr code path. When BuildStreamUrl
+            // falls back to a direct Xtream URL, the codec opt-out must not apply — stats already
+            // suppress probing, so dropping the codec hint leaves the direct fallback with neither
+            // codec declaration nor probe. ShouldUseStatsCodec pins this gate.
+            var useStatsCodec = ShouldUseStatsCodec(isDispatcharr, config.DispatcharrUseStatsCodec);
+
+            var mediaSource = CreateMediaSourceInfo(streamId, streamUrl, stats, isDispatcharr, config.ForceAudioTranscode, config.HttpUserAgent, config.FallbackTranscodeBitrateMbps, config.DeclareDvbSubtitles, useStatsCodec, Logger);
             Logger.Info("[stream-timing] ch={0} CreateMediaSource={1}ms hasStats={2}", tunerChannel?.Name, sw.ElapsedMilliseconds, stats != null);
 
             return new List<MediaSourceInfo> { mediaSource };
@@ -945,7 +951,13 @@ namespace Emby.Xtream.Plugin.Service
             Logger.Info("[stream-timing] ch={0} BuildUrl={1}ms isDispatcharr={2}", tunerChannel?.Name, sw.ElapsedMilliseconds, isDispatcharr);
             sw.Restart();
 
-            var mediaSource = CreateMediaSourceInfo(streamId, streamUrl, stats, isDispatcharr, config.ForceAudioTranscode, config.HttpUserAgent, config.FallbackTranscodeBitrateMbps, config.DeclareDvbSubtitles, config.DispatcharrUseStatsCodec, Logger);
+            // DispatcharrUseStatsCodec only governs the Dispatcharr code path. When BuildStreamUrl
+            // falls back to a direct Xtream URL, the codec opt-out must not apply — stats already
+            // suppress probing, so dropping the codec hint leaves the direct fallback with neither
+            // codec declaration nor probe. ShouldUseStatsCodec pins this gate.
+            var useStatsCodec = ShouldUseStatsCodec(isDispatcharr, config.DispatcharrUseStatsCodec);
+
+            var mediaSource = CreateMediaSourceInfo(streamId, streamUrl, stats, isDispatcharr, config.ForceAudioTranscode, config.HttpUserAgent, config.FallbackTranscodeBitrateMbps, config.DeclareDvbSubtitles, useStatsCodec, Logger);
             Logger.Info("[stream-timing] ch={0} CreateMediaSource={1}ms hasStats={2}", tunerChannel?.Name, sw.ElapsedMilliseconds, stats != null);
 
             var httpClient = Plugin.CreateHttpClient();
@@ -1852,6 +1864,25 @@ namespace Emby.Xtream.Plugin.Service
             // hasVideoCodecFromStats, but re-checking useStatsCodec here means a caller
             // that forgets to mask upstream still gets the right answer.
             return hasVideoCodecFromStats && useStatsCodec;
+        }
+
+        /// <summary>
+        /// Gates the <see cref="PluginConfiguration.DispatcharrUseStatsCodec"/> opt-out to
+        /// Dispatcharr sources. When <paramref name="isDispatcharr"/> is false (direct Xtream
+        /// fallback from <see cref="BuildStreamUrl"/>), stats already suppress probing, so
+        /// dropping the codec hint would leave the direct fallback with neither codec
+        /// declaration nor probe. Treat direct Xtream sources as codec-trusted by default.
+        /// Regression for CodeRabbit finding on PR #67 head 8c2e46e.
+        /// </summary>
+        internal static bool ShouldUseStatsCodec(bool isDispatcharr, bool dispatcharrUseStatsCodec)
+        {
+            // Truth table:
+            //   isDispatcharr | dispatcharrUseStatsCodec | useStatsCodec?
+            //   true          | true                     | true  (Dispatcharr + default)
+            //   true          | false                    | false (Dispatcharr + opt-out, issue #66)
+            //   false         | true                     | true  (direct Xtream + default)
+            //   false         | false                    | true  (direct Xtream: opt-out N/A)
+            return !isDispatcharr || dispatcharrUseStatsCodec;
         }
 
         /// <summary>

--- a/Emby.Xtream.Plugin/Service/XtreamTunerHost.cs
+++ b/Emby.Xtream.Plugin/Service/XtreamTunerHost.cs
@@ -910,7 +910,7 @@ namespace Emby.Xtream.Plugin.Service
 
             _streamStats.TryGetValue(streamId, out var stats);
 
-            var mediaSource = CreateMediaSourceInfo(streamId, streamUrl, stats, isDispatcharr, config.ForceAudioTranscode, config.HttpUserAgent, config.FallbackTranscodeBitrateMbps, config.DeclareDvbSubtitles);
+            var mediaSource = CreateMediaSourceInfo(streamId, streamUrl, stats, isDispatcharr, config.ForceAudioTranscode, config.HttpUserAgent, config.FallbackTranscodeBitrateMbps, config.DeclareDvbSubtitles, config.DispatcharrUseStatsCodec);
             Logger.Info("[stream-timing] ch={0} CreateMediaSource={1}ms hasStats={2}", tunerChannel?.Name, sw.ElapsedMilliseconds, stats != null);
 
             return new List<MediaSourceInfo> { mediaSource };
@@ -944,7 +944,7 @@ namespace Emby.Xtream.Plugin.Service
             Logger.Info("[stream-timing] ch={0} BuildUrl={1}ms isDispatcharr={2}", tunerChannel?.Name, sw.ElapsedMilliseconds, isDispatcharr);
             sw.Restart();
 
-            var mediaSource = CreateMediaSourceInfo(streamId, streamUrl, stats, isDispatcharr, config.ForceAudioTranscode, config.HttpUserAgent, config.FallbackTranscodeBitrateMbps, config.DeclareDvbSubtitles);
+            var mediaSource = CreateMediaSourceInfo(streamId, streamUrl, stats, isDispatcharr, config.ForceAudioTranscode, config.HttpUserAgent, config.FallbackTranscodeBitrateMbps, config.DeclareDvbSubtitles, config.DispatcharrUseStatsCodec);
             Logger.Info("[stream-timing] ch={0} CreateMediaSource={1}ms hasStats={2}", tunerChannel?.Name, sw.ElapsedMilliseconds, stats != null);
 
             var httpClient = Plugin.CreateHttpClient();
@@ -1438,7 +1438,8 @@ namespace Emby.Xtream.Plugin.Service
         private MediaSourceInfo CreateMediaSourceInfo(
             int streamId, string streamUrl, StreamStatsInfo stats,
             bool disableProbing = false, bool forceAudioTranscode = false,
-            string userAgent = null, int fallbackBitrateMbps = 0, bool declareDvbSubtitles = false)
+            string userAgent = null, int fallbackBitrateMbps = 0, bool declareDvbSubtitles = false,
+            bool useStatsCodec = true)
         {
             var sourceId = "xtream_live_" + streamId.ToString(CultureInfo.InvariantCulture);
 
@@ -1449,13 +1450,28 @@ namespace Emby.Xtream.Plugin.Service
                 && stats.VideoCodec == null
                 && !string.IsNullOrEmpty(stats.AudioCodec);
 
-            bool hasStats = stats?.VideoCodec != null || isAudioOnly;
+            // When useStatsCodec is false on a Dispatcharr URL, ignore the codec field from
+            // stream_stats entirely. That field is the codec Dispatcharr *ingested* from the
+            // source, not the codec it *emits*. If the Dispatcharr stream profile transcodes
+            // (e.g. HEVC source → H.264 output), declaring the source codec forces Emby to
+            // apply the wrong decoder and the channel fails to play (issue #66). By treating
+            // the codec as absent we let Emby probe the proxy URL and discover the actual
+            // output. Audio-only detection still works because it uses AudioCodec, which we
+            // keep honouring.
+            bool hasVideoCodecFromStats = stats?.VideoCodec != null && useStatsCodec;
+            bool hasStats = hasVideoCodecFromStats || isAudioOnly;
 
             // Disable probing for Dispatcharr proxy URLs: the probe opens a short-lived HTTP
             // connection that Dispatcharr interprets as a client, and when it closes after
             // analysis (~0.1s) Dispatcharr tears down the channel. The real playback connection
             // then hits the teardown and fails, causing a rapid retry storm.
-            bool suppressProbing = disableProbing || hasStats;
+            //
+            // Exception (issue #66): when the user has opted out of the stats codec
+            // (DispatcharrUseStatsCodec=false), the input codec is unknown to be the output
+            // codec, so the source MUST be probed to discover the actual output. Drop the
+            // disableProbing flag in that case — probing is exactly the user-requested escape.
+            bool effectiveDisableProbing = ShouldDisableProbing(disableProbing, useStatsCodec);
+            bool suppressProbing = ShouldSuppressProbing(effectiveDisableProbing, hasStats);
 
             var audioCodecLower = hasStats && !string.IsNullOrEmpty(stats.AudioCodec)
                 ? stats.AudioCodec.ToLowerInvariant() : null;
@@ -1754,6 +1770,35 @@ namespace Emby.Xtream.Plugin.Service
             if (upper == "HEVC" || upper == "H265") return "hevc";
             if (upper == "MPEG2VIDEO") return "mpeg2video";
             return dispatcharrCodec.ToLowerInvariant();
+        }
+
+        /// <summary>
+        /// Decides whether the Live TV MediaSource should be probed by Emby.
+        /// Extracted from <see cref="CreateMediaSourceInfo"/> so a regression test can
+        /// exercise the decision without instantiating a full MediaSourceInfo. Probing
+        /// is suppressed on Dispatcharr URLs because the probe opens a short-lived HTTP
+        /// connection that Dispatcharr interprets as a client and tears down on close,
+        /// causing a retry storm. The caller decides whether to pass through the
+        /// dispatcharr-side <paramref name="disableProbing"/> flag (issue #66: it must
+        /// be cleared when the user has opted out of stats codec, so probing actually
+        /// runs and Emby discovers the real output codec).
+        /// </summary>
+        internal static bool ShouldSuppressProbing(bool disableProbing, bool hasStats)
+        {
+            return disableProbing || hasStats;
+        }
+
+        /// <summary>
+        /// Resolves the effective probing-disable flag for the Live TV MediaSource.
+        /// Issue #66: when the user has opted out of the stats codec
+        /// (<paramref name="useStatsCodec"/> = false), the input codec is unknown to
+        /// be the output codec, so probing must run. The dispatcharr-side
+        /// <paramref name="disableProbing"/> flag is dropped in that case. Extracted for
+        /// direct regression testing without instantiating a full MediaSourceInfo.
+        /// </summary>
+        internal static bool ShouldDisableProbing(bool disableProbing, bool useStatsCodec)
+        {
+            return disableProbing && useStatsCodec;
         }
     }
 }

--- a/Emby.Xtream.Plugin/Service/XtreamTunerHost.cs
+++ b/Emby.Xtream.Plugin/Service/XtreamTunerHost.cs
@@ -1736,8 +1736,9 @@ namespace Emby.Xtream.Plugin.Service
                 mediaSource.MediaStreams = new List<MediaStream> { videoStream, audioStream };
                 mediaSource.DefaultAudioStreamIndex = 1;
                 LogDebug(logger,
-                    "Stream {0}: no stats available, will probe (fallback bitrate {1} Mbps)",
-                    streamId, fallbackBitrateMbps);
+                    "Stream {0}: no stats available, {1} (fallback bitrate {2} Mbps)",
+                    streamId, suppressProbing ? "probing disabled" : "will probe",
+                    fallbackBitrateMbps);
             }
 
             return mediaSource;

--- a/Emby.Xtream.Plugin/Service/XtreamTunerHost.cs
+++ b/Emby.Xtream.Plugin/Service/XtreamTunerHost.cs
@@ -1551,9 +1551,8 @@ namespace Emby.Xtream.Plugin.Service
                         }
                     }
 
-                    var videoCodec = ShouldDeclareVideoCodec(hasVideoCodecFromStats, useStatsCodec)
-                        ? MapVideoCodec(stats.VideoCodec)
-                        : null;
+                    var declareVideoCodec = ShouldDeclareVideoCodec(hasVideoCodecFromStats, useStatsCodec);
+                    var videoCodec = declareVideoCodec ? MapVideoCodec(stats.VideoCodec) : null;
 
                     var videoStream = new MediaStream
                     {
@@ -1573,14 +1572,24 @@ namespace Emby.Xtream.Plugin.Service
                         videoStream.AverageFrameRate = (float)stats.SourceFps.Value;
                     }
                     if (stats.Bitrate.HasValue) videoStream.BitRate = (int)(stats.Bitrate.Value * 1000);
-                    if (!string.IsNullOrEmpty(stats.VideoProfile))
-                        videoStream.Profile = stats.VideoProfile;
-                    if (stats.VideoLevel.HasValue)
-                        videoStream.Level = (double)stats.VideoLevel.Value;
-                    if (stats.VideoBitDepth.HasValue)
-                        videoStream.BitDepth = stats.VideoBitDepth.Value;
-                    if (stats.VideoRefFrames.HasValue)
-                        videoStream.RefFrames = stats.VideoRefFrames.Value;
+
+                    // Profile, level, bit depth and reference frames describe the codec Dispatcharr
+                    // ingested, so they are only as trustworthy as the codec itself. When the stream
+                    // profile transcodes (issue #66) they describe the source, not the bytes Emby
+                    // receives: a level number means something different in HEVC than in H.264, and
+                    // bit depth and reference frames need not survive a re-encode. Resolution, FPS
+                    // and ffmpeg_output_bitrate describe the output and stay honoured either way.
+                    if (declareVideoCodec)
+                    {
+                        if (!string.IsNullOrEmpty(stats.VideoProfile))
+                            videoStream.Profile = stats.VideoProfile;
+                        if (stats.VideoLevel.HasValue)
+                            videoStream.Level = (double)stats.VideoLevel.Value;
+                        if (stats.VideoBitDepth.HasValue)
+                            videoStream.BitDepth = stats.VideoBitDepth.Value;
+                        if (stats.VideoRefFrames.HasValue)
+                            videoStream.RefFrames = stats.VideoRefFrames.Value;
+                    }
 
                     mediaStreams.Add(videoStream);
                 }

--- a/docs/decisions/016-dispatcharr-stats-codec-trust.md
+++ b/docs/decisions/016-dispatcharr-stats-codec-trust.md
@@ -82,7 +82,7 @@ Audio-only detection is preserved unchanged: `isAudioOnly` still reads `stats.Au
 ## Consequences
 
 - **Existing installs**: no behavior change. `DispatcharrUseStatsCodec = true` is the default and reproduces the legacy trust-stats-codec path verbatim.
-- **Affected users** (Dispatcharr stream profile transcoding): a single checkbox in Plugin Config. The codec field is left unset on the `MediaStream`; Emby picks whatever decoder the actual bytes need. Display title shows resolution only (`"1080p"`) instead of resolution + codec.
+- **Affected users** (Dispatcharr stream profile transcoding): a single checkbox, *Plugin Config → Dispatcharr → Declare Dispatcharr's reported video codec*, on by default. Unticking it leaves the codec field unset on the `MediaStream`; Emby picks whatever decoder the actual bytes need. Display title shows resolution only (`"1080p"`) instead of resolution + codec.
 - **API surface**: `PluginConfiguration.DispatcharrUseStatsCodec` (new field, defaults to `true` — existing config XML files deserialize unchanged).
 - **Tests**: `XtreamTunerHostTests.cs` pins both helpers and `BuildVideoDisplayTitle` (4-row Theory for ShouldSuppressProbing, 4-row Theory for ShouldDeclareVideoCodec, 5-row Theory for BuildVideoDisplayTitle, plus Facts covering the reporter's exact bug inputs end-to-end). All green.
 - **AGENTS.md alignment**: the fix lives entirely within the "don't probe, don't falsely declare" envelope. The absolute no-probe rule for `/proxy/ts/stream/{uuid}` URLs is unchanged.
@@ -90,12 +90,16 @@ Audio-only detection is preserved unchanged: `isAudioOnly` still reads `stats.Au
 
 ## Code Citations
 
-- Bug confirmed: `XtreamTunerHost.cs:1529-1531` (codec declaration from `stats.VideoCodec`).
-- Original probe-disable: `XtreamTunerHost.cs:1479` (`suppressProbing = disableProbing || hasStats`).
-- Fix (new helpers + escape route): `XtreamTunerHost.cs:1451-1469` (audio detection + hasVideoCodecFromStats + HasStats gating), `XtreamTunerHost.cs:1536-1551` (codec declaration + display title).
-- Static helpers for regression testing: `XtreamTunerHost.cs:1790-1862` (`ShouldSuppressProbing`, `HasStats`, `ShouldDeclareVideoCodec`, `BuildVideoDisplayTitle`).
-- Config: `PluginConfiguration.cs:51-68` (new `DispatcharrUseStatsCodec` field).
-- Tests: `Emby.Xtream.Plugin.Tests/XtreamTunerHostTests.cs` (regression rows for the helpers plus end-to-end hand-walk).
+Cited by symbol rather than line number: this ADR has already been through one
+commit whose only purpose was re-syncing line references, and they went stale
+again three commits later.
+
+- Bug and fix both live in `XtreamTunerHost.CreateMediaSourceInfo`, in the `if (hasStats)` branch that builds the video `MediaStream`.
+- Probe suppression: `XtreamTunerHost.ShouldSuppressProbing` (`disableProbing || hasStats`), unchanged by this ADR.
+- Decision helpers: `ShouldSuppressProbing`, `HasStats`, `ShouldDeclareVideoCodec`, `ShouldUseStatsCodec`, `BuildVideoDisplayTitle`.
+- Config: `PluginConfiguration.DispatcharrUseStatsCodec`.
+- UI: `Configuration/Web/config.html` (`chkDispatcharrUseStatsCodec`, in the Dispatcharr section) and the matching read/write pair in `config.js`.
+- Tests: `Emby.Xtream.Plugin.Tests/XtreamTunerHostTests.cs` (helper truth tables, factory output for the opt-out and for the direct-Xtream fallback).
 
 ## Follow-up: `hasStats` gate was over-coupled to codec trust
 
@@ -123,3 +127,51 @@ The fix: replace the `hasVideoCodecFromStats || isAudioOnly` expression with `st
 `XtreamTunerHostTests.Issue66_HasStats_TracksStatsPresenceNotVideoCodec_Gate` pins this table. With the helper in place, the original ADR claim ("Audio codec, resolution, FPS, bitrate, profile, and level keep flowing from stats regardless of the toggle") is now actually true.
 
 The discovery was a useful reminder: the original `hasStats = hasVideoCodecFromStats || isAudioOnly` looked symmetric and tidy, but it conflated "stats are present" with "the codec field on the stats is trustworthy". Once the codec gate split off into `ShouldDeclareVideoCodec`, the only thing left to check was stats presence.
+
+## Follow-up: codec-derived attributes follow the codec
+
+**Date**: 2026-09-05
+
+The first cut gated the codec but kept declaring `Profile`, `Level`, `BitDepth` and
+`RefFrames` from the same `stream_stats` object. Those four describe the codec
+Dispatcharr ingested, so they are worth exactly as much as the codec field is: a level
+number means something different in HEVC than in H.264, and neither bit depth nor
+reference-frame count needs to survive a re-encode. Declaring `Main / level 41 / 10-bit`
+from an HEVC source on an H.264 output is the same bug class as #66, one field over.
+
+They now sit behind the same `ShouldDeclareVideoCodec` gate as the codec itself. What
+stays honoured on the opt-out path is what genuinely describes the output: resolution,
+frame rate, `ffmpeg_output_bitrate` (output-side, per its own name) and everything on
+the audio stream. Both sides of the gate are pinned in
+`XtreamTunerHostTests.CreateMediaSourceInfo_DispatcharrOptOut_*` (omitted) and
+`CreateMediaSourceInfo_DirectXtreamFallback_*` (declared).
+
+## Open verification: an unset codec on the recording path
+
+**Status**: not yet verified on a real server.
+
+The chosen alternative rests on one claim: that Emby, handed a video `MediaStream` with
+no codec, works the decoder out from the bytes. That is asserted in this ADR without a
+source, and the no-stats fallback branch in the same method carries a comment claiming
+the opposite:
+
+> Codec must be non-null: Emby's `RecordingRequiresEncoding` accesses it directly and
+> throws `NullReferenceException` when it is null.
+
+That comment arrived with commit `75a616a`, whose message attributes the crash it fixed
+to a null `liveStream` rather than a null codec, and whose only codec-related change was
+on the audio side. So the comment may be a conclusion drawn too broadly from that
+debugging session, or an accurate separate observation. The test suite cannot settle it:
+every test here asserts either a boolean truth table or the shape of the returned
+`MediaSourceInfo`, and none of them has Emby consume that object.
+
+What settles it is one opted-out channel played *and* recorded on a real server.
+`RecordingRequiresEncoding` sits on the timer path, not the playback path, so playback
+succeeding proves nothing about recording. If the crash is real, alternative 4 is dead
+and the route is the one the reporter proposed in the PR thread: read the channel's
+stream profile command string through the connector the plugin already authenticates to
+and map `-c:v h264_nvenc`/`libx264` → `h264`, `hevc_nvenc`/`libx265` → `hevc`, `copy` →
+stats as today. That declares a correct non-null codec, keeps the display title, needs
+no probe, and makes this question moot. Alternative 1 above rejects a weaker version of
+that idea (a user-maintained profile-ID → codec map) for reasons that do not apply to
+parsing a string the plugin can already read.

--- a/docs/decisions/016-dispatcharr-stats-codec-trust.md
+++ b/docs/decisions/016-dispatcharr-stats-codec-trust.md
@@ -20,6 +20,8 @@ The reporter (VoltsLee, issue [#66](https://github.com/firestaerter3/emby-xtream
 
 The plugin has one declaration policy ("trust stats, suppress probing") that is correct for pass-through and wrong for transcoded streams. There is no way to distinguish the two cases from `stream_stats` alone — Dispatcharr does not currently expose the profile output codec via this endpoint.
 
+The no-probe rule for `/proxy/ts/stream/{uuid}` URLs is absolute (`docs/AGENTS.md → "Emby probes MediaSource.Path directly — disable for Dispatcharr"`): the probe opens a short-lived HTTP connection that Dispatcharr interprets as a client and tears down on close, so probing MUST stay disabled for these URLs regardless of stats availability. Any fix for the codec-mismatch bug must respect this rule.
+
 ## Alternatives Considered
 
 ### 1. Per-profile output codec map in plugin settings (reporter suggestion)
@@ -33,23 +35,14 @@ Add a config setting `DispatcharrProfileOutputCodecs: Dictionary<int, string>` k
 - The reporter's actual channel list spans multiple profiles — they'd need to enter all of them.
 - Adds UI surface that most users never need.
 
-### 2. Re-enable probing when the user opts out of stats codec (chosen)
+### 2. Re-enable probing when the user opts out of stats codec (originally chosen, then revised)
 
-Add a single boolean `DispatcharrUseStatsCodec` (default `true`, preserves current behavior). When `false`:
-- The plugin ignores `stats.VideoCodec`.
-- `hasStats` collapses to "audio-only or absent".
-- The dispatcharr-side `disableProbing` flag is dropped, so probing is allowed to run.
-- Emby probes the proxy URL and discovers the actual output codec on first tune (~100ms cost).
+Add a single boolean `DispatcharrUseStatsCodec` (default `true`). When `false`, drop the dispatcharr-side `disableProbing` flag so probing runs and Emby discovers the output codec.
 
-**Pros**:
-- Single user-facing toggle. No per-profile state to maintain.
-- Restores the plugin's correct behavior (declare nothing → let Emby discover).
-- Default `true` keeps all existing installs unchanged. Users who hit the bug flip a checkbox.
-- Probing is a well-understood mechanism. The dispatcharr-side teardown concern (ADR-001) is mitigated by `channel_shutdown_delay` — a Dispatcharr setting the user already controls.
-
+**Pros**: Single toggle, restores the correct behavior via the documented probing mechanism.
 **Cons**:
-- Adds ~100ms to first tune on Dispatcharr streams for affected users (acceptable, documented).
-- The dispatcharr teardown concern is back into scope for these users. Document the `channel_shutdown_delay` mitigation in the config flag's XML doc.
+- Violates the absolute no-probe rule in `docs/AGENTS.md` for `/proxy/ts/stream/{uuid}` URLs. CodeRabbit flagged this as a `🟠 Major` finding on PR #67 — the dispatcharr teardown concern returns even with `channel_shutdown_delay` set, because the teardown happens *before* `channel_shutdown_delay` starts ticking (the probe connection closes too quickly).
+- Re-introduces the documented retry-storm risk for affected users.
 
 ### 3. Always probe (no opt-out)
 
@@ -57,31 +50,49 @@ Drop the trust-stats-codec path entirely. Always let Emby probe.
 
 **Cons**: Breaks every existing Dispatcharr install. The teardown storm returns for users who haven't set `channel_shutdown_delay`. Too aggressive.
 
-### 4. Wait for Dispatcharr to add a `stream_profile_output_codec` field
+### 4. Leave the codec field unset on the MediaStream when the user opts out of stats codec (chosen)
+
+Add a single boolean `DispatcharrUseStatsCodec` (default `true`, preserves current behavior). When `false`, the plugin ignores `stats.VideoCodec` and leaves the codec field unset on the video `MediaStream`. Probing stays disabled (per `docs/AGENTS.md`). Resolution, FPS, bitrate, profile, level, and audio codec continue to flow from stats — only the video codec and its display title are gated.
+
+Emby's behaviour when codec is unset: it applies whatever decoder the actual MPEG-TS bytes need. Pass-through streams (H.264 bytes in, H.264 bytes out) play correctly because the decoder matches the bytes. Transcoded streams (HEVC source, H.264 bytes out) play correctly because the codec field does not falsely claim HEVC. There is a small visual cost: the player UI shows `"1080p"` instead of `"1080p H264"` for affected channels, but playback works.
+
+**Pros**:
+- Single user-facing toggle. No per-profile state to maintain.
+- Respects the absolute no-probe rule for Dispatcharr proxy URLs (`docs/AGENTS.md`).
+- Default `true` keeps all existing installs unchanged. Users who hit the bug flip a checkbox.
+- No probing cost, no teardown risk, no `channel_shutdown_delay` dependency.
+- Audio codec, resolution, FPS, bitrate, profile, and level keep flowing from stats regardless of the toggle.
+
+**Cons**:
+- The display title loses the codec label for affected channels (`"1080p"` instead of `"1080p H264"`). Acceptable: playback matters more than the label.
+- Users who set `DispatcharrUseStatsCodec = false` lose the codec hint Emby would otherwise have. This is the explicit trade-off the toggle captures.
+
+### 5. Wait for Dispatcharr to add a `stream_profile_output_codec` field
 
 Out of our control. Filing a Dispatcharr issue is a good follow-up, but the reporter's channels are broken *today*.
 
 ## Decision
 
-**Alternative 2**: add `DispatcharrUseStatsCodec` (default `true`). When `false`, the plugin ignores `stats.VideoCodec` and allows probing.
+**Alternative 4**: add `DispatcharrUseStatsCodec` (default `true`). When `false`, the plugin ignores `stats.VideoCodec` and leaves the codec field unset on the video `MediaStream`. Probing stays disabled.
 
-The decision logic is split into two static helpers, `XtreamTunerHost.ShouldSuppressProbing` and `XtreamTunerHost.ShouldDisableProbing`, so regression tests can pin the truth table without instantiating a full `MediaSourceInfo` (the static `_streamStats` cache blocks full integration tests — see the placeholder in `XtreamTunerHostTests.cs`).
+The decision logic is split into two static helpers, `XtreamTunerHost.ShouldSuppressProbing` and `XtreamTunerHost.ShouldDeclareVideoCodec`, so regression tests can pin the truth tables without instantiating a full `MediaSourceInfo` (the static `_streamStats` cache blocks full integration tests — see the placeholder in `XtreamTunerHostTests.cs`). A third helper, `XtreamTunerHost.BuildVideoDisplayTitle`, owns the four-shape display-title contract.
 
 Audio-only detection is preserved unchanged: `isAudioOnly` still reads `stats.AudioCodec` regardless of `DispatcharrUseStatsCodec`. The audio flag remains trustworthy in all configurations.
 
 ## Consequences
 
 - **Existing installs**: no behavior change. `DispatcharrUseStatsCodec = true` is the default and reproduces the legacy trust-stats-codec path verbatim.
-- **Affected users** (Dispatcharr stream profile transcoding): a single checkbox in Plugin Config. Probing restores correct codec discovery at the cost of ~100ms on first tune.
+- **Affected users** (Dispatcharr stream profile transcoding): a single checkbox in Plugin Config. The codec field is left unset on the `MediaStream`; Emby picks whatever decoder the actual bytes need. Display title shows resolution only (`"1080p"`) instead of resolution + codec.
 - **API surface**: `PluginConfiguration.DispatcharrUseStatsCodec` (new field, defaults to `true` — existing config XML files deserialize unchanged).
-- **Tests**: `XtreamTunerHostTests.cs` adds 11 regression rows (4-row Theory + 3-row Theory + 4 Facts) pinning both helpers and a hand-walk through the reporter's exact bug inputs.
+- **Tests**: `XtreamTunerHostTests.cs` pins both helpers and `BuildVideoDisplayTitle` (4-row Theory for ShouldSuppressProbing, 4-row Theory for ShouldDeclareVideoCodec, 5-row Theory for BuildVideoDisplayTitle, plus Facts covering the reporter's exact bug inputs end-to-end). All green.
+- **AGENTS.md alignment**: the fix lives entirely within the "don't probe, don't falsely declare" envelope. The absolute no-probe rule for `/proxy/ts/stream/{uuid}` URLs is unchanged.
 - **Future work**: file an upstream Dispatcharr issue asking for `stream_profile_output_codec` on the stream-stats endpoint. If/when shipped, `DispatcharrUseStatsCodec` can be deprecated and the plugin can auto-detect transcoding profiles.
-- **Operational note**: probe-induced teardown concern returns for opted-out users. Mitigation is the existing `channel_shutdown_delay` setting in Dispatcharr — users who opt out of stats codec must set it to a positive value to avoid the retry storm documented in ADR-001. The XML doc on the config field calls this out.
 
 ## Code Citations
 
 - Bug confirmed: `XtreamTunerHost.cs:1515-1521` (codec declaration from `stats.VideoCodec`).
 - Original probe-disable: `XtreamTunerHost.cs:1458` (`suppressProbing = disableProbing || hasStats`).
-- Fix (new helpers + escape route): `XtreamTunerHost.cs:1458-1468` (`ShouldDisableProbing` + `ShouldSuppressProbing` wiring).
+- Fix (new helpers + escape route): `XtreamTunerHost.cs:1446-1457` (audio detection + hasVideoCodecFromStats gating), `XtreamTunerHost.cs:1529-1543` (codec declaration + display title).
+- Static helpers for regression testing: `XtreamTunerHost.cs:1775-1834` (`ShouldSuppressProbing`, `ShouldDeclareVideoCodec`, `BuildVideoDisplayTitle`).
 - Config: `PluginConfiguration.cs:51-68` (new `DispatcharrUseStatsCodec` field).
-- Tests: `Emby.Xtream.Plugin.Tests/XtreamTunerHostTests.cs` (12 tests, 0 skipped, all green).
+- Tests: `Emby.Xtream.Plugin.Tests/XtreamTunerHostTests.cs` (regression rows for both helpers plus end-to-end hand-walk).

--- a/docs/decisions/016-dispatcharr-stats-codec-trust.md
+++ b/docs/decisions/016-dispatcharr-stats-codec-trust.md
@@ -90,9 +90,36 @@ Audio-only detection is preserved unchanged: `isAudioOnly` still reads `stats.Au
 
 ## Code Citations
 
-- Bug confirmed: `XtreamTunerHost.cs:1515-1521` (codec declaration from `stats.VideoCodec`).
-- Original probe-disable: `XtreamTunerHost.cs:1458` (`suppressProbing = disableProbing || hasStats`).
-- Fix (new helpers + escape route): `XtreamTunerHost.cs:1446-1457` (audio detection + hasVideoCodecFromStats gating), `XtreamTunerHost.cs:1529-1543` (codec declaration + display title).
-- Static helpers for regression testing: `XtreamTunerHost.cs:1775-1834` (`ShouldSuppressProbing`, `ShouldDeclareVideoCodec`, `BuildVideoDisplayTitle`).
+- Bug confirmed: `XtreamTunerHost.cs:1529-1531` (codec declaration from `stats.VideoCodec`).
+- Original probe-disable: `XtreamTunerHost.cs:1479` (`suppressProbing = disableProbing || hasStats`).
+- Fix (new helpers + escape route): `XtreamTunerHost.cs:1451-1469` (audio detection + hasVideoCodecFromStats + HasStats gating), `XtreamTunerHost.cs:1536-1551` (codec declaration + display title).
+- Static helpers for regression testing: `XtreamTunerHost.cs:1790-1862` (`ShouldSuppressProbing`, `HasStats`, `ShouldDeclareVideoCodec`, `BuildVideoDisplayTitle`).
 - Config: `PluginConfiguration.cs:51-68` (new `DispatcharrUseStatsCodec` field).
-- Tests: `Emby.Xtream.Plugin.Tests/XtreamTunerHostTests.cs` (regression rows for both helpers plus end-to-end hand-walk).
+- Tests: `Emby.Xtream.Plugin.Tests/XtreamTunerHostTests.cs` (regression rows for the helpers plus end-to-end hand-walk).
+
+## Follow-up: `hasStats` gate was over-coupled to codec trust
+
+**Date**: 2026-09-02
+**Trigger**: CodeRabbit review on PR [#67](https://github.com/firestaerter3/emby-xtream/pull/67) head `3c6d056` (review 5084623350 at 01:07:35Z).
+
+The original implementation wrote
+
+```csharp
+bool hasVideoCodecFromStats = stats?.VideoCodec != null && useStatsCodec;
+bool hasStats = hasVideoCodecFromStats || isAudioOnly;
+```
+
+on the assumption that `hasStats` would always be true when we have any stats to honour. The coupling was wrong: when a video channel had `DispatcharrUseStatsCodec = false`, `hasVideoCodecFromStats` collapsed to false, and a video channel is not audio-only, so `hasStats` collapsed to false. The `if (hasStats) { ... }` block then skipped every stat-derived field — resolution, FPS, bitrate, audio codec, audio channels, video profile/level/bit depth/reference frames. Emby ended up with a `MediaSource` whose video `MediaStream` had no codec, no width, no height, no frame rate, and no audio stream at all. The "Audio codec, resolution, FPS, bitrate, profile, and level keep flowing from stats regardless of the toggle" claim in the Consequences section above turned out to be wrong.
+
+The fix: replace the `hasVideoCodecFromStats || isAudioOnly` expression with `stats != null` (extracted into a new static helper `XtreamTunerHost.HasStats(statsPresent, isAudioOnly)` for symmetry with the other decision helpers and to make the bug class regression-testable). The video codec declaration stays gated separately by `ShouldDeclareVideoCodec`. Truth table for `HasStats`:
+
+| stats != null | isAudioOnly | hasStats | Notes                                        |
+|---------------|-------------|----------|----------------------------------------------|
+| true          | false       | true     | video channel, legacy or opt-out            |
+| true          | true        | true     | audio-only channel                           |
+| false         | false       | false    | no stats at all (Dispatcharr 404 / cache miss) |
+| false         | true        | false    | unreachable: isAudioOnly implies stats != null |
+
+`XtreamTunerHostTests.Issue66_HasStats_TracksStatsPresenceNotVideoCodec_Gate` pins this table. With the helper in place, the original ADR claim ("Audio codec, resolution, FPS, bitrate, profile, and level keep flowing from stats regardless of the toggle") is now actually true.
+
+The discovery was a useful reminder: the original `hasStats = hasVideoCodecFromStats || isAudioOnly` looked symmetric and tidy, but it conflated "stats are present" with "the codec field on the stats is trustworthy". Once the codec gate split off into `ShouldDeclareVideoCodec`, the only thing left to check was stats presence.

--- a/docs/decisions/016-dispatcharr-stats-codec-trust.md
+++ b/docs/decisions/016-dispatcharr-stats-codec-trust.md
@@ -14,7 +14,7 @@ That logic is correct for streams where Dispatcharr is a pure pass-through. The 
 
 But Dispatcharr also supports stream profiles that transcode. A common configuration is "HEVC source → H.264 output for compatibility". In that mode, `stream_stats.video_codec` reports `hevc` (the ingested codec), while the bytes leaving the proxy are H.264. Reporting `hevc` to Emby on the MediaSource causes Emby to force the HEVC decoder on the output — which fails, because the bytes are H.264.
 
-The reporter (VoltsLee, issue [#66](https://github.com/firestaerter3/emby-xtream/issues/66)) hit this on 13 channels. Confirmed in code at `XtreamTunerHost.cs:1515-1521` (codec declaration) and `XtreamTunerHost.cs:1458` (`suppressProbing = disableProbing || hasStats`).
+The reporter (VoltsLee, issue [#66](https://github.com/firestaerter3/emby-xtream/issues/66)) hit this on 13 channels. Confirmed in code at `XtreamTunerHost.cs:1529-1531` (codec declaration) and `XtreamTunerHost.cs:1479` (`suppressProbing = disableProbing || hasStats`).
 
 ## Problem
 

--- a/docs/decisions/016-dispatcharr-stats-codec-trust.md
+++ b/docs/decisions/016-dispatcharr-stats-codec-trust.md
@@ -1,177 +1,177 @@
-# ADR-016: Don't Trust Dispatcharr `stream_stats.video_codec` When a Stream Profile Transcodes
+# ADR-016: Take the Dispatcharr Video Codec From the Stream Profile, Not From `stream_stats`
 
-**Date**: 2026-09-02
+**Date**: 2026-09-05 (supersedes the 2026-09-02 draft of this ADR, which chose alternative 4)
 **Status**: Accepted
-**Affects**: `XtreamTunerHost.CreateMediaSourceInfo()`, `PluginConfiguration.DispatcharrUseStatsCodec`
+**Affects**: `XtreamTunerHost.CreateMediaSourceInfo()`, `XtreamTunerHost.ResolveVideoCodec()`, `StreamProfileCodec`, `DispatcharrClient`, `PluginConfiguration.DispatcharrVideoCodecSource`
 
 ---
 
 ## Context
 
-When Dispatcharr is enabled and `stream_stats` are cached for a stream, `XtreamTunerHost.CreateMediaSourceInfo` has been declaring the codec from `stats.VideoCodec` on the Live TV `MediaSource` and setting `SupportsProbing = false`. The reasoning: probing opens a short-lived HTTP connection that Dispatcharr interprets as a client and tears down on close, causing a retry storm (see ADR-001 and `docs/AGENTS.md → "Emby probes MediaSource.Path directly — disable for Dispatcharr"`).
+When Dispatcharr is enabled and `stream_stats` are cached for a stream, `CreateMediaSourceInfo`
+declared the codec from `stats.VideoCodec` on the Live TV `MediaSource` and set
+`SupportsProbing = false`. Probing has to stay off: the probe opens a short-lived HTTP
+connection that Dispatcharr reads as a client and tears down on close, causing a retry storm
+(ADR-001 and `AGENTS.md → "Emby probes MediaSource.Path directly — disable for Dispatcharr"`).
 
-That logic is correct for streams where Dispatcharr is a pure pass-through. The codec Dispatcharr reports on `stream_stats.video_codec` is the codec it *ingested* from the source — the same bytes leaving the proxy.
+That is correct while Dispatcharr is a pure pass-through, because the codec it ingested is also
+the codec it emits. But Dispatcharr supports stream profiles that transcode, and "HEVC source →
+H.264 output for compatibility" is a common one. There `stream_stats.video_codec` says `hevc`
+while the bytes leaving the proxy are H.264, Emby forces the HEVC decoder on an H.264 stream,
+ffmpeg floods `Invalid NAL unit` and exits, and the client shows "No compatible streams are
+currently available".
 
-But Dispatcharr also supports stream profiles that transcode. A common configuration is "HEVC source → H.264 output for compatibility". In that mode, `stream_stats.video_codec` reports `hevc` (the ingested codec), while the bytes leaving the proxy are H.264. Reporting `hevc` to Emby on the MediaSource causes Emby to force the HEVC decoder on the output — which fails, because the bytes are H.264.
-
-The reporter (VoltsLee, issue [#66](https://github.com/firestaerter3/emby-xtream/issues/66)) hit this on 13 channels. Confirmed in code at `XtreamTunerHost.cs:1529-1531` (codec declaration) and `XtreamTunerHost.cs:1479` (`suppressProbing = disableProbing || hasStats`).
+The reporter (VoltsLee, issue [#66](https://github.com/firestaerter3/emby-xtream/issues/66)) hit
+this on 13 channels, growing as more channels get probed by Dispatcharr and gain stats.
 
 ## Problem
 
-The plugin has one declaration policy ("trust stats, suppress probing") that is correct for pass-through and wrong for transcoded streams. There is no way to distinguish the two cases from `stream_stats` alone — Dispatcharr does not currently expose the profile output codec via this endpoint.
-
-The no-probe rule for `/proxy/ts/stream/{uuid}` URLs is absolute (`docs/AGENTS.md → "Emby probes MediaSource.Path directly — disable for Dispatcharr"`): the probe opens a short-lived HTTP connection that Dispatcharr interprets as a client and tears down on close, so probing MUST stay disabled for these URLs regardless of stats availability. Any fix for the codec-mismatch bug must respect this rule.
+One declaration policy ("trust stats, suppress probing") is right for pass-through and wrong for
+transcoding, and `stream_stats` alone cannot tell the two apart. Any fix has to respect the
+absolute no-probe rule for `/proxy/ts/stream/{uuid}` URLs, and it has to give Emby a codec:
+the no-stats branch of the same method records that `RecordingRequiresEncoding` dereferences
+`MediaStream.Codec`, so a null there turns a recording into a `NullReferenceException`.
 
 ## Alternatives Considered
 
-### 1. Per-profile output codec map in plugin settings (reporter suggestion)
+### 1. Per-profile output codec map in plugin settings
 
-Add a config setting `DispatcharrProfileOutputCodecs: Dictionary<int, string>` keyed by stream profile ID. When a channel uses a transcoding profile, the plugin reads the output codec from this map instead of `stream_stats.video_codec`.
+A `Dictionary<int, string>` in config, keyed by stream profile ID, filled in by the user.
 
-**Pros**: Most precise. The plugin declares exactly what Dispatcharr will emit.
-**Cons**:
-- Requires the user to know which profile their channel uses and which output codec it produces.
-- Profile IDs are server-side identifiers that can change across Dispatcharr versions.
-- The reporter's actual channel list spans multiple profiles — they'd need to enter all of them.
-- Adds UI surface that most users never need.
+**Rejected**: the user has to know which profile each channel uses and what it outputs, profile
+IDs are server-side and can change, and the reporter's channels span several profiles.
 
-### 2. Re-enable probing when the user opts out of stats codec (originally chosen, then revised)
+### 2. Re-enable probing when the user opts out of the stats codec
 
-Add a single boolean `DispatcharrUseStatsCodec` (default `true`). When `false`, drop the dispatcharr-side `disableProbing` flag so probing runs and Emby discovers the output codec.
+Drop the Dispatcharr `disableProbing` flag so Emby discovers the output codec itself.
 
-**Pros**: Single toggle, restores the correct behavior via the documented probing mechanism.
-**Cons**:
-- Violates the absolute no-probe rule in `docs/AGENTS.md` for `/proxy/ts/stream/{uuid}` URLs. CodeRabbit flagged this as a `🟠 Major` finding on PR #67 — the dispatcharr teardown concern returns even with `channel_shutdown_delay` set, because the teardown happens *before* `channel_shutdown_delay` starts ticking (the probe connection closes too quickly).
-- Re-introduces the documented retry-storm risk for affected users.
+**Rejected**: violates the no-probe rule. CodeRabbit flagged it Major on PR #67. The teardown
+fires when the probe connection closes, before `channel_shutdown_delay` starts counting, so
+setting that delay does not save it.
 
-### 3. Always probe (no opt-out)
+### 3. Always probe, no opt-out
 
-Drop the trust-stats-codec path entirely. Always let Emby probe.
+**Rejected**: breaks every existing Dispatcharr install and brings the teardown storm back for
+everyone who has not set `channel_shutdown_delay`.
 
-**Cons**: Breaks every existing Dispatcharr install. The teardown storm returns for users who haven't set `channel_shutdown_delay`. Too aggressive.
+### 4. Leave the codec field unset when the user opts out
 
-### 4. Leave the codec field unset on the MediaStream when the user opts out of stats codec (chosen)
+Add a boolean; when off, declare no video codec at all and let Emby work it out from the bytes.
+This was the accepted decision in the first version of this ADR and shipped as
+`DispatcharrUseStatsCodec` on PR #67.
 
-Add a single boolean `DispatcharrUseStatsCodec` (default `true`, preserves current behavior). When `false`, the plugin ignores `stats.VideoCodec` and leaves the codec field unset on the video `MediaStream`. Probing stays disabled (per `docs/AGENTS.md`). Resolution, FPS, bitrate, profile, level, and audio codec continue to flow from stats — only the video codec and its display title are gated.
+**Rejected on review.** The claim it rests on — that Emby picks the decoder from the bytes when
+the codec is unset — was never verified against a real server, and the no-stats branch of the
+same method says the opposite in a comment:
 
-Emby's behaviour when codec is unset: it applies whatever decoder the actual MPEG-TS bytes need. Pass-through streams (H.264 bytes in, H.264 bytes out) play correctly because the decoder matches the bytes. Transcoded streams (HEVC source, H.264 bytes out) play correctly because the codec field does not falsely claim HEVC. There is a small visual cost: the player UI shows `"1080p"` instead of `"1080p H264"` for affected channels, but playback works.
+> Codec must be non-null: Emby's `RecordingRequiresEncoding` accesses it directly and throws
+> `NullReferenceException` when it is null.
 
-**Pros**:
-- Single user-facing toggle. No per-profile state to maintain.
-- Respects the absolute no-probe rule for Dispatcharr proxy URLs (`docs/AGENTS.md`).
-- Default `true` keeps all existing installs unchanged. Users who hit the bug flip a checkbox.
-- No probing cost, no teardown risk, no `channel_shutdown_delay` dependency.
-- Audio codec, resolution, FPS, bitrate, profile, and level keep flowing from stats regardless of the toggle.
+That comment came in with `75a616a`, whose message attributes the crash it fixed to a null
+`liveStream` rather than a null codec, so it may be drawn too broadly. Codex review on PR #67
+reached the same conclusion independently and marked it P1: the setting deliberately steers
+users with transcoding profiles onto the null path, so if the comment is right, the fix breaks
+recordings for exactly the people it is meant to help. No test in the suite can settle it, since
+none of them has Emby consume the `MediaSourceInfo`.
 
-**Cons**:
-- The display title loses the codec label for affected channels (`"1080p"` instead of `"1080p H264"`). Acceptable: playback matters more than the label.
-- Users who set `DispatcharrUseStatsCodec = false` lose the codec hint Emby would otherwise have. This is the explicit trade-off the toggle captures.
+The deciding argument is that alternative 6 makes the question moot rather than answering it.
 
-### 5. Wait for Dispatcharr to add a `stream_profile_output_codec` field
+### 5. Wait for Dispatcharr to expose the profile output codec on the stats endpoint
 
-Out of our control. Filing a Dispatcharr issue is a good follow-up, but the reporter's channels are broken *today*.
+**Rejected as the primary fix**: out of our control, and the reporter's channels are broken now.
+Still worth filing upstream.
+
+### 6. Read the output codec from the channel's stream profile (chosen)
+
+Dispatcharr already knows what it emits, because the user configured it: each channel resolves to
+a stream profile, and the profile's `parameters` string carries the ffmpeg arguments. `-c:v
+h264_nvenc` means H.264 leaves the proxy whatever went in. The reporter proposed this in the
+PR #67 thread.
+
+**Chosen.** It declares a correct, non-null codec, needs no probe, and costs one extra pair of
+API calls on the cached refresh path rather than anything at playback time.
 
 ## Decision
 
-**Alternative 4**: add `DispatcharrUseStatsCodec` (default `true`). When `false`, the plugin ignores `stats.VideoCodec` and leaves the codec field unset on the video `MediaStream`. Probing stays disabled.
+The plugin resolves the declared video codec in this order, for Dispatcharr URLs:
 
-The decision logic is split into two static helpers, `XtreamTunerHost.ShouldSuppressProbing` and `XtreamTunerHost.ShouldDeclareVideoCodec`, so regression tests can pin the truth tables without instantiating a full `MediaSourceInfo` (the static `_streamStats` cache blocks full integration tests — see the placeholder in `XtreamTunerHostTests.cs`). A third helper, `XtreamTunerHost.BuildVideoDisplayTitle`, owns the four-shape display-title contract.
+1. **The channel's stream profile**, parsed by `StreamProfileCodec.Parse` from the profile's
+   command and parameters. `-c:v`, `-c:v:0`, `-codec:v`, `-vcodec` and bare `-c`/`-codec` are all
+   read, last occurrence wins (that is how ffmpeg resolves them), and the encoder name is mapped
+   onto a codec: `libx264`/`h264_*` → `h264`, `libx265`/`hevc_*`/`h265_*` → `hevc`, `mpeg2*` →
+   `mpeg2video`.
+2. **`stream_stats.video_codec`**, when the profile has no answer. `copy`, a non-ffmpeg profile
+   (the built-in redirect and proxy profiles, streamlink, custom scripts), an unrecognised
+   encoder, an unreadable profile endpoint and an unresolvable profile ID all count as "no
+   answer". That is deliberate: an unknown encoder returns null rather than its own name, because
+   handing Emby `av1_nvenc` as a codec is worse than handing it nothing.
+3. **`h264`**, when neither knows. This is the same fallback the no-stats branch has always used,
+   and it exists so that no configuration can produce a null codec.
 
-Audio-only detection is preserved unchanged: `isAudioOnly` still reads `stats.AudioCodec` regardless of `DispatcharrUseStatsCodec`. The audio flag remains trustworthy in all configurations.
+Channel → profile comes from `effective_stream_profile_id` (override-aware, newer serializers)
+falling back to `stream_profile_id`, and a channel with neither uses the server's
+`default_stream_profile` setting. All of it is fetched during the cached channel refresh, never
+at playback: doing Dispatcharr lookups per play is what BUG-007 was about, and it put ~3s on the
+first tune.
+
+Probing stays off. Nothing in this ADR touches that.
+
+`PluginConfiguration.DispatcharrVideoCodecSource` (default `auto`) overrides the resolution for
+installs where profile detection cannot work or gets it wrong: `stats` restores the pre-#66
+behaviour, `h264` and `hevc` declare that codec on every Dispatcharr channel. All three are
+non-null by construction. It appears as *Video codec for Dispatcharr channels* in the Dispatcharr
+section of the config page.
+
+Direct Xtream URLs (the `DispatcharrFallbackToXtream` path) always use the reported codec: those
+bytes are the provider's own, so the profile does not describe them and the Dispatcharr setting
+does not apply.
 
 ## Consequences
 
-- **Existing installs**: no behavior change. `DispatcharrUseStatsCodec = true` is the default and reproduces the legacy trust-stats-codec path verbatim.
-- **Affected users** (Dispatcharr stream profile transcoding): a single checkbox, *Plugin Config → Dispatcharr → Declare Dispatcharr's reported video codec*, on by default. Unticking it leaves the codec field unset on the `MediaStream`; Emby picks whatever decoder the actual bytes need. Display title shows resolution only (`"1080p"`) instead of resolution + codec.
-- **API surface**: `PluginConfiguration.DispatcharrUseStatsCodec` (new field, defaults to `true` — existing config XML files deserialize unchanged).
-- **Tests**: `XtreamTunerHostTests.cs` pins both helpers and `BuildVideoDisplayTitle` (4-row Theory for ShouldSuppressProbing, 4-row Theory for ShouldDeclareVideoCodec, 5-row Theory for BuildVideoDisplayTitle, plus Facts covering the reporter's exact bug inputs end-to-end). All green.
-- **AGENTS.md alignment**: the fix lives entirely within the "don't probe, don't falsely declare" envelope. The absolute no-probe rule for `/proxy/ts/stream/{uuid}` URLs is unchanged.
-- **Future work**: file an upstream Dispatcharr issue asking for `stream_profile_output_codec` on the stream-stats endpoint. If/when shipped, `DispatcharrUseStatsCodec` can be deprecated and the plugin can auto-detect transcoding profiles.
+- **Pass-through installs**: no change. The profile has no answer, so the reported codec is used
+  exactly as before.
+- **Transcoding installs**: channels that failed with "No compatible streams are currently
+  available" now play, with no setting to find and no checkbox to tick. The player still shows
+  resolution and codec, because a codec is always declared.
+- **Codec-derived attributes**: `Profile`, `Level`, `BitDepth` and `RefFrames` describe the
+  ingested codec, so they are only declared when the declared codec *is* the reported one
+  (`ShouldDeclareCodecAttributes`). Declaring "Main / level 41 / 10-bit" from an HEVC source on an
+  H.264 output is #66 one field over. Resolution, frame rate, `ffmpeg_output_bitrate` and the
+  audio stream describe the output and are always honoured.
+- **Recording**: no path declares a null codec any more, so the `RecordingRequiresEncoding`
+  question is closed by construction rather than by testing.
+- **Extra API calls**: two per cached refresh (`/api/core/streamprofiles/` and
+  `/api/core/settings/`), none per playback. Both failing is a supported state and degrades to
+  the reported codec.
+- **Older Dispatcharr / restricted accounts**: an empty profile list or a missing setting logs at
+  info level and falls back to the reported codec, which is the pre-#66 behaviour rather than an
+  error.
+- **API surface**: `DispatcharrVideoCodecSource` replaces the unreleased `DispatcharrUseStatsCodec`
+  from earlier commits on this branch. Existing config XML has neither field and deserializes to
+  `auto`.
+
+## Follow-up
+
+- File a Dispatcharr issue asking for the emitted codec on the stream-stats endpoint. If it ever
+  lands, `StreamProfileCodec` becomes a fallback for older servers instead of the primary source.
+- Extend the encoder map when a real profile shows up that it does not recognise. The parser
+  fails safe, so an unknown encoder is a missed fix rather than a broken channel.
 
 ## Code Citations
 
-Cited by symbol rather than line number: this ADR has already been through one
-commit whose only purpose was re-syncing line references, and they went stale
-again three commits later.
+Cited by symbol rather than line number: this ADR has already been through one commit whose only
+purpose was re-syncing line references, and they went stale again three commits later.
 
-- Bug and fix both live in `XtreamTunerHost.CreateMediaSourceInfo`, in the `if (hasStats)` branch that builds the video `MediaStream`.
-- Probe suppression: `XtreamTunerHost.ShouldSuppressProbing` (`disableProbing || hasStats`), unchanged by this ADR.
-- Decision helpers: `ShouldSuppressProbing`, `HasStats`, `ShouldDeclareVideoCodec`, `ShouldUseStatsCodec`, `BuildVideoDisplayTitle`.
-- Config: `PluginConfiguration.DispatcharrUseStatsCodec`.
-- UI: `Configuration/Web/config.html` (`chkDispatcharrUseStatsCodec`, in the Dispatcharr section) and the matching read/write pair in `config.js`.
-- Tests: `Emby.Xtream.Plugin.Tests/XtreamTunerHostTests.cs` (helper truth tables, factory output for the opt-out and for the direct-Xtream fallback).
-
-## Follow-up: `hasStats` gate was over-coupled to codec trust
-
-**Date**: 2026-09-02
-**Trigger**: CodeRabbit review on PR [#67](https://github.com/firestaerter3/emby-xtream/pull/67) head `3c6d056` (review 5084623350 at 01:07:35Z).
-
-The original implementation wrote
-
-```csharp
-bool hasVideoCodecFromStats = stats?.VideoCodec != null && useStatsCodec;
-bool hasStats = hasVideoCodecFromStats || isAudioOnly;
-```
-
-on the assumption that `hasStats` would always be true when we have any stats to honour. The coupling was wrong: when a video channel had `DispatcharrUseStatsCodec = false`, `hasVideoCodecFromStats` collapsed to false, and a video channel is not audio-only, so `hasStats` collapsed to false. The `if (hasStats) { ... }` block then skipped every stat-derived field — resolution, FPS, bitrate, audio codec, audio channels, video profile/level/bit depth/reference frames. Emby ended up with a `MediaSource` whose video `MediaStream` had no codec, no width, no height, no frame rate, and no audio stream at all. The "Audio codec, resolution, FPS, bitrate, profile, and level keep flowing from stats regardless of the toggle" claim in the Consequences section above turned out to be wrong.
-
-The fix: replace the `hasVideoCodecFromStats || isAudioOnly` expression with `stats != null` (extracted into a new static helper `XtreamTunerHost.HasStats(statsPresent, isAudioOnly)` for symmetry with the other decision helpers and to make the bug class regression-testable). The video codec declaration stays gated separately by `ShouldDeclareVideoCodec`. Truth table for `HasStats`:
-
-| stats != null | isAudioOnly | hasStats | Notes                                        |
-|---------------|-------------|----------|----------------------------------------------|
-| true          | false       | true     | video channel, legacy or opt-out            |
-| true          | true        | true     | audio-only channel                           |
-| false         | false       | false    | no stats at all (Dispatcharr 404 / cache miss) |
-| false         | true        | false    | unreachable: isAudioOnly implies stats != null |
-
-`XtreamTunerHostTests.Issue66_HasStats_TracksStatsPresenceNotVideoCodec_Gate` pins this table. With the helper in place, the original ADR claim ("Audio codec, resolution, FPS, bitrate, profile, and level keep flowing from stats regardless of the toggle") is now actually true.
-
-The discovery was a useful reminder: the original `hasStats = hasVideoCodecFromStats || isAudioOnly` looked symmetric and tidy, but it conflated "stats are present" with "the codec field on the stats is trustworthy". Once the codec gate split off into `ShouldDeclareVideoCodec`, the only thing left to check was stats presence.
-
-## Follow-up: codec-derived attributes follow the codec
-
-**Date**: 2026-09-05
-
-The first cut gated the codec but kept declaring `Profile`, `Level`, `BitDepth` and
-`RefFrames` from the same `stream_stats` object. Those four describe the codec
-Dispatcharr ingested, so they are worth exactly as much as the codec field is: a level
-number means something different in HEVC than in H.264, and neither bit depth nor
-reference-frame count needs to survive a re-encode. Declaring `Main / level 41 / 10-bit`
-from an HEVC source on an H.264 output is the same bug class as #66, one field over.
-
-They now sit behind the same `ShouldDeclareVideoCodec` gate as the codec itself. What
-stays honoured on the opt-out path is what genuinely describes the output: resolution,
-frame rate, `ffmpeg_output_bitrate` (output-side, per its own name) and everything on
-the audio stream. Both sides of the gate are pinned in
-`XtreamTunerHostTests.CreateMediaSourceInfo_DispatcharrOptOut_*` (omitted) and
-`CreateMediaSourceInfo_DirectXtreamFallback_*` (declared).
-
-## Open verification: an unset codec on the recording path
-
-**Status**: not yet verified on a real server.
-
-The chosen alternative rests on one claim: that Emby, handed a video `MediaStream` with
-no codec, works the decoder out from the bytes. That is asserted in this ADR without a
-source, and the no-stats fallback branch in the same method carries a comment claiming
-the opposite:
-
-> Codec must be non-null: Emby's `RecordingRequiresEncoding` accesses it directly and
-> throws `NullReferenceException` when it is null.
-
-That comment arrived with commit `75a616a`, whose message attributes the crash it fixed
-to a null `liveStream` rather than a null codec, and whose only codec-related change was
-on the audio side. So the comment may be a conclusion drawn too broadly from that
-debugging session, or an accurate separate observation. The test suite cannot settle it:
-every test here asserts either a boolean truth table or the shape of the returned
-`MediaSourceInfo`, and none of them has Emby consume that object.
-
-What settles it is one opted-out channel played *and* recorded on a real server.
-`RecordingRequiresEncoding` sits on the timer path, not the playback path, so playback
-succeeding proves nothing about recording. If the crash is real, alternative 4 is dead
-and the route is the one the reporter proposed in the PR thread: read the channel's
-stream profile command string through the connector the plugin already authenticates to
-and map `-c:v h264_nvenc`/`libx264` → `h264`, `hevc_nvenc`/`libx265` → `hevc`, `copy` →
-stats as today. That declares a correct non-null codec, keeps the display title, needs
-no probe, and makes this question moot. Alternative 1 above rejects a weaker version of
-that idea (a user-maintained profile-ID → codec map) for reasons that do not apply to
-parsing a string the plugin can already read.
+- Resolution order: `XtreamTunerHost.ResolveVideoCodec`, applied at both playback call sites.
+- Profile parsing and the stream-id → codec map: `StreamProfileCodec.Parse` / `BuildCodecMap`.
+- Fetch path: `XtreamTunerHost.BuildProfileCodecMapAsync`, `DispatcharrClient.GetStreamProfilesAsync`,
+  `DispatcharrClient.GetDefaultStreamProfileIdAsync`.
+- Per-channel profile IDs: `DispatcharrChannelWithStreams.ResolvedStreamProfileId`, mapped under
+  both keys in `DispatcharrClient.GetChannelDataAsync`.
+- Attribute gate: `XtreamTunerHost.ShouldDeclareCodecAttributes`.
+- Probe suppression, unchanged: `XtreamTunerHost.ShouldSuppressProbing`.
+- Config: `PluginConfiguration.DispatcharrVideoCodecSource`; UI in `Configuration/Web/config.html`
+  (`selDispatcharrCodecSource`) and the read/write pair in `config.js`.
+- Tests: `XtreamTunerHostTests` (parser table, resolution table, attribute gate, assembled
+  `MediaSourceInfo` per scenario, and the guarantee that no path declares a null codec) and
+  `DispatcharrClientTests` (both endpoints, and the dual-key profile-ID map).

--- a/docs/decisions/016-dispatcharr-stats-codec-trust.md
+++ b/docs/decisions/016-dispatcharr-stats-codec-trust.md
@@ -1,0 +1,87 @@
+# ADR-016: Don't Trust Dispatcharr `stream_stats.video_codec` When a Stream Profile Transcodes
+
+**Date**: 2026-09-02
+**Status**: Accepted
+**Affects**: `XtreamTunerHost.CreateMediaSourceInfo()`, `PluginConfiguration.DispatcharrUseStatsCodec`
+
+---
+
+## Context
+
+When Dispatcharr is enabled and `stream_stats` are cached for a stream, `XtreamTunerHost.CreateMediaSourceInfo` has been declaring the codec from `stats.VideoCodec` on the Live TV `MediaSource` and setting `SupportsProbing = false`. The reasoning: probing opens a short-lived HTTP connection that Dispatcharr interprets as a client and tears down on close, causing a retry storm (see ADR-001 and `docs/AGENTS.md → "Emby probes MediaSource.Path directly — disable for Dispatcharr"`).
+
+That logic is correct for streams where Dispatcharr is a pure pass-through. The codec Dispatcharr reports on `stream_stats.video_codec` is the codec it *ingested* from the source — the same bytes leaving the proxy.
+
+But Dispatcharr also supports stream profiles that transcode. A common configuration is "HEVC source → H.264 output for compatibility". In that mode, `stream_stats.video_codec` reports `hevc` (the ingested codec), while the bytes leaving the proxy are H.264. Reporting `hevc` to Emby on the MediaSource causes Emby to force the HEVC decoder on the output — which fails, because the bytes are H.264.
+
+The reporter (VoltsLee, issue [#66](https://github.com/firestaerter3/emby-xtream/issues/66)) hit this on 13 channels. Confirmed in code at `XtreamTunerHost.cs:1515-1521` (codec declaration) and `XtreamTunerHost.cs:1458` (`suppressProbing = disableProbing || hasStats`).
+
+## Problem
+
+The plugin has one declaration policy ("trust stats, suppress probing") that is correct for pass-through and wrong for transcoded streams. There is no way to distinguish the two cases from `stream_stats` alone — Dispatcharr does not currently expose the profile output codec via this endpoint.
+
+## Alternatives Considered
+
+### 1. Per-profile output codec map in plugin settings (reporter suggestion)
+
+Add a config setting `DispatcharrProfileOutputCodecs: Dictionary<int, string>` keyed by stream profile ID. When a channel uses a transcoding profile, the plugin reads the output codec from this map instead of `stream_stats.video_codec`.
+
+**Pros**: Most precise. The plugin declares exactly what Dispatcharr will emit.
+**Cons**:
+- Requires the user to know which profile their channel uses and which output codec it produces.
+- Profile IDs are server-side identifiers that can change across Dispatcharr versions.
+- The reporter's actual channel list spans multiple profiles — they'd need to enter all of them.
+- Adds UI surface that most users never need.
+
+### 2. Re-enable probing when the user opts out of stats codec (chosen)
+
+Add a single boolean `DispatcharrUseStatsCodec` (default `true`, preserves current behavior). When `false`:
+- The plugin ignores `stats.VideoCodec`.
+- `hasStats` collapses to "audio-only or absent".
+- The dispatcharr-side `disableProbing` flag is dropped, so probing is allowed to run.
+- Emby probes the proxy URL and discovers the actual output codec on first tune (~100ms cost).
+
+**Pros**:
+- Single user-facing toggle. No per-profile state to maintain.
+- Restores the plugin's correct behavior (declare nothing → let Emby discover).
+- Default `true` keeps all existing installs unchanged. Users who hit the bug flip a checkbox.
+- Probing is a well-understood mechanism. The dispatcharr-side teardown concern (ADR-001) is mitigated by `channel_shutdown_delay` — a Dispatcharr setting the user already controls.
+
+**Cons**:
+- Adds ~100ms to first tune on Dispatcharr streams for affected users (acceptable, documented).
+- The dispatcharr teardown concern is back into scope for these users. Document the `channel_shutdown_delay` mitigation in the config flag's XML doc.
+
+### 3. Always probe (no opt-out)
+
+Drop the trust-stats-codec path entirely. Always let Emby probe.
+
+**Cons**: Breaks every existing Dispatcharr install. The teardown storm returns for users who haven't set `channel_shutdown_delay`. Too aggressive.
+
+### 4. Wait for Dispatcharr to add a `stream_profile_output_codec` field
+
+Out of our control. Filing a Dispatcharr issue is a good follow-up, but the reporter's channels are broken *today*.
+
+## Decision
+
+**Alternative 2**: add `DispatcharrUseStatsCodec` (default `true`). When `false`, the plugin ignores `stats.VideoCodec` and allows probing.
+
+The decision logic is split into two static helpers, `XtreamTunerHost.ShouldSuppressProbing` and `XtreamTunerHost.ShouldDisableProbing`, so regression tests can pin the truth table without instantiating a full `MediaSourceInfo` (the static `_streamStats` cache blocks full integration tests — see the placeholder in `XtreamTunerHostTests.cs`).
+
+Audio-only detection is preserved unchanged: `isAudioOnly` still reads `stats.AudioCodec` regardless of `DispatcharrUseStatsCodec`. The audio flag remains trustworthy in all configurations.
+
+## Consequences
+
+- **Existing installs**: no behavior change. `DispatcharrUseStatsCodec = true` is the default and reproduces the legacy trust-stats-codec path verbatim.
+- **Affected users** (Dispatcharr stream profile transcoding): a single checkbox in Plugin Config. Probing restores correct codec discovery at the cost of ~100ms on first tune.
+- **API surface**: `PluginConfiguration.DispatcharrUseStatsCodec` (new field, defaults to `true` — existing config XML files deserialize unchanged).
+- **Tests**: `XtreamTunerHostTests.cs` adds 11 regression rows (4-row Theory + 3-row Theory + 4 Facts) pinning both helpers and a hand-walk through the reporter's exact bug inputs.
+- **Future work**: file an upstream Dispatcharr issue asking for `stream_profile_output_codec` on the stream-stats endpoint. If/when shipped, `DispatcharrUseStatsCodec` can be deprecated and the plugin can auto-detect transcoding profiles.
+- **Operational note**: probe-induced teardown concern returns for opted-out users. Mitigation is the existing `channel_shutdown_delay` setting in Dispatcharr — users who opt out of stats codec must set it to a positive value to avoid the retry storm documented in ADR-001. The XML doc on the config field calls this out.
+
+## Code Citations
+
+- Bug confirmed: `XtreamTunerHost.cs:1515-1521` (codec declaration from `stats.VideoCodec`).
+- Original probe-disable: `XtreamTunerHost.cs:1458` (`suppressProbing = disableProbing || hasStats`).
+- Fix (new helpers + escape route): `XtreamTunerHost.cs:1458-1468` (`ShouldDisableProbing` + `ShouldSuppressProbing` wiring).
+- Config: `PluginConfiguration.cs:51-68` (new `DispatcharrUseStatsCodec` field).
+- Tests: `Emby.Xtream.Plugin.Tests/XtreamTunerHostTests.cs` (12 tests, 0 skipped, all green).

--- a/docs/decisions/016-dispatcharr-stats-codec-trust.md
+++ b/docs/decisions/016-dispatcharr-stats-codec-trust.md
@@ -97,9 +97,11 @@ The plugin resolves the declared video codec in this order, for Dispatcharr URLs
 
 1. **The channel's stream profile**, parsed by `StreamProfileCodec.Parse` from the profile's
    command and parameters. `-c:v`, `-c:v:0`, `-codec:v`, `-vcodec` and bare `-c`/`-codec` are all
-   read, last occurrence wins (that is how ffmpeg resolves them), and the encoder name is mapped
-   onto a codec: `libx264`/`h264_*` → `h264`, `libx265`/`hevc_*`/`h265_*` → `hevc`, `mpeg2*` →
-   `mpeg2video`.
+   read in their spaced (`-c:v h264_nvenc`), joined (`-c:v=h264_nvenc`) and quoted
+   (`-c:v "h264_nvenc"`) forms, last occurrence wins (that is how ffmpeg resolves them), and the
+   encoder name is mapped onto a codec: `libx264`/`h264_*` → `h264`, `libx265`/`hevc_*`/`h265_*`
+   → `hevc`, `mpeg2*` → `mpeg2video`. The parameters string is typed by hand in Dispatcharr's UI,
+   so all three forms turn up in real profiles.
 2. **`stream_stats.video_codec`**, when the profile has no answer. `copy`, a non-ffmpeg profile
    (the built-in redirect and proxy profiles, streamlink, custom scripts), an unrecognised
    encoder, an unreadable profile endpoint and an unresolvable profile ID all count as "no
@@ -110,9 +112,12 @@ The plugin resolves the declared video codec in this order, for Dispatcharr URLs
 
 Channel → profile comes from `effective_stream_profile_id` (override-aware, newer serializers)
 falling back to `stream_profile_id`, and a channel with neither uses the server's
-`default_stream_profile` setting. All of it is fetched during the cached channel refresh, never
-at playback: doing Dispatcharr lookups per play is what BUG-007 was about, and it put ~3s on the
-first tune.
+`default_stream_profile` setting. All of it is fetched during the cached channel refresh: doing Dispatcharr
+lookups per play is what BUG-007 was about, and it put ~3s on the first tune. The on-demand path
+that runs when a tune arrives before the cache exists is the one exception, and there the two
+profile requests are started before the channel-data request and awaited after it, so they
+overlap with a call that was already happening instead of queueing two round trips in front of
+playback.
 
 Probing stays off. Nothing in this ADR touches that.
 
@@ -141,8 +146,12 @@ does not apply.
 - **Recording**: no path declares a null codec any more, so the `RecordingRequiresEncoding`
   question is closed by construction rather than by testing.
 - **Extra API calls**: two per cached refresh (`/api/core/streamprofiles/` and
-  `/api/core/settings/`), none per playback. Both failing is a supported state and degrades to
-  the reported codec.
+  `/api/core/settings/`), issued concurrently with the channel-data call rather than after it.
+  Both failing is a supported state and degrades to the reported codec.
+- **Settings shapes**: older servers return a flat row per setting, newer ones group them and put
+  the profile inside `stream_settings`, as a JSON object or as a JSON-encoded string. A live
+  Dispatcharr 0.29 install returns the grouped shape and no `effective_stream_profile_id` at all,
+  so both fallbacks are load-bearing rather than defensive.
 - **Older Dispatcharr / restricted accounts**: an empty profile list or a missing setting logs at
   info level and falls back to the reported codec, which is the pre-#66 behaviour rather than an
   error.


### PR DESCRIPTION
## Summary

Fixes [#66](https://github.com/firestaerter3/emby-xtream/issues/66).

When Dispatcharr is enabled and `stream_stats` are cached, `XtreamTunerHost.CreateMediaSourceInfo` was declaring the codec from `stats.VideoCodec` on the Live TV `MediaSource` and disabling probing. That field is the codec Dispatcharr **ingested** from the source, not the codec it **emits**. On channels whose Dispatcharr stream profile transcodes (e.g. HEVC source → H.264 output), the plugin was forcing Emby to apply the wrong decoder on the output and the channel failed to play.

This PR adds an opt-out: `DispatcharrUseStatsCodec` (default `true`, preserves legacy behavior). When `false`, the plugin ignores `stats.VideoCodec`, collapses `hasStats` to audio-only-or-absent, and lets Emby probe the proxy URL to discover the actual output codec. Audio-only detection still honours `stats.AudioCodec` regardless.

The decision logic is split into two internal static helpers, `ShouldSuppressProbing` and `ShouldDisableProbing`, so regression tests pin the truth table without instantiating a full `MediaSourceInfo` (the static `_streamStats` cache still blocks full integration tests — see ADR-016 for the rationale).

ADR-016 records the decision, the alternatives considered (per-profile output codec map, always-probe, wait for upstream), and the operational caveat: opted-out users must set `channel_shutdown_delay > 0` in Dispatcharr to avoid the probe-induced teardown storm from ADR-001. The XML doc on the new config field calls this out.

## Test plan

- 11 regression rows added in `XtreamTunerHostTests.cs`: 4-row `Theory` for `ShouldSuppressProbing`, 4-row `Theory` for `ShouldDisableProbing`, 4 `Fact`s including an end-to-end hand-walk through the reporter's exact bug inputs (Dispatcharr path, `hevc` codec, `DispatcharrUseStatsCodec = false` → probing allowed).
- Existing `Placeholder_StaticStreamStatsCachePreventsIsolation` preserved (now runs with the new context instead of skipped).
- Full suite: `dotnet test` returns 0, 440 passed / 0 failed / 0 skipped.

## Reproduction

Reporter: 13 channels failing on Emby 4.9.5.0 with Dispatcharr v0.29.0 stream profile that transcodes HEVC → H.264. Confirmed in code at `XtreamTunerHost.cs:1515-1521` (codec declaration from `stats.VideoCodec`) and `XtreamTunerHost.cs:1458` (`suppressProbing = disableProbing || hasStats`).

## Checklist

- [x] Regression test included
- [x] ADR added (`docs/decisions/016-dispatcharr-stats-codec-trust.md`)
- [x] Default value preserves existing behavior
- [x] Local `dotnet test` green (440 / 0 / 0)
- [ ] CodeRabbit review on this head
- [ ] Maintainer merge approval


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to use Dispatcharr’s reported video codec for Live TV streams.
  * Added an opt-out setting that lets Emby detect the proxy’s actual output codec while retaining stream statistics.

* **Bug Fixes**
  * Corrected codec declaration, display-title, and probing behavior when the option is disabled.
  * Preserved audio-only detection and supported stream handling.

* **Tests**
  * Added regression coverage for codec selection, stream statistics, display titles, and probing scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->