### PR TITLE
Document the awaiting-verification label

### DIFF
--- a/docs/agent-labels.md
+++ b/docs/agent-labels.md
@@ -15,6 +15,7 @@ These labels support automated issue triage, implementation routing, and maintai
 | `provider-issue` | Root cause is likely upstream provider data or behavior. |
 | `configuration` | Root cause is likely setup, local Emby behavior, or documented configuration. |
 | `regression` | Behavior previously worked and appears broken by a recent change. |
+| `awaiting-verification` | Fix is released and the issue stays open until the reporter confirms it. |
 
 ## Recommended setup
 
@@ -32,4 +33,5 @@ gh label create low-value --color C5DEF5 --description "Low value, narrow, or hi
 gh label create provider-issue --color FBCA04 --description "Likely caused by provider data or behavior"
 gh label create configuration --color BFDADC --description "Likely setup or configuration issue"
 gh label create regression --color E99695 --description "Previously worked and now broken"
+gh label create awaiting-verification --color C2E0C6 --description "Fix is released, waiting for the reporter to confirm"
 ```

--- a/docs/agent-triage-policy.md
+++ b/docs/agent-triage-policy.md
@@ -59,6 +59,14 @@ Use `configuration` or `provider-issue` when the evidence points outside plugin 
 
 Use `needs-info` when key details are missing. Ask precise questions and do not open an implementation PR.
 
+### Awaiting verification
+
+Use `awaiting-verification` on an issue whose fix has shipped but has not been confirmed by the
+reporter, and reopen the issue if merging closed it. It means the work is done, so do not treat
+it as open work: no implementation PR, and never `agent-ready`. The label comes off when the
+reporter confirms (close the issue) or reports it is still broken (back to `needs-info` or
+`dev-ready`, whichever fits).
+
 ## Agent-ready gate
 
 Apply `agent-ready` only when all are true:


### PR DESCRIPTION
`#66` needed a label for "fix shipped, waiting for the reporter to confirm" and there wasn't one. `needs-info` means the issue is missing reproduction details, which is the opposite case, and leaving `dev-ready` on a fixed issue reads as open work.

The label now exists in the repo. This adds it to the table and the setup snippet in `docs/agent-labels.md`, which the triage workflow reads, plus a rule in the triage policy: the work is done, so it is never `agent-ready`, and the label comes off when the reporter answers either way.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for marking issues as **Awaiting verification** after a fix has shipped but still needs confirmation.
  * Documented the lifecycle for this status, including next steps when the fix is confirmed or remains unresolved.
  * Added instructions for creating and applying the `awaiting-verification` label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->